### PR TITLE
fix: read __version__ from package metadata

### DIFF
--- a/src/metapulsar/__init__.py
+++ b/src/metapulsar/__init__.py
@@ -5,6 +5,13 @@ collaborations (EPTA, PPTA, NANOGrav, MPTA, etc.) into unified "metapulsar"
 objects for gravitational wave detection.
 """
 
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("metapulsar")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+
 # Core classes
 from .metapulsar import MetaPulsar
 from .metapulsar_factory import (
@@ -46,7 +53,6 @@ from .selection_utils import create_staggered_selection
 from .pint_helpers import PINTDiscoveryError
 
 
-__version__ = "0.1.0"
 __author__ = "Rutger van Haasteren, Wangwei Yu, David Wright"
 __email__ = "rutger@vhaasteren.com"
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,9 @@
+"""Ensure package __version__ stays aligned with installed distribution metadata."""
+
+from importlib.metadata import version
+
+import metapulsar
+
+
+def test_version_matches_metadata():
+    assert metapulsar.__version__ == version("metapulsar")


### PR DESCRIPTION
## Summary

`metapulsar.__version__` was a fixed literal (`0.1.0`), so notebooks and docs could show the wrong version after installing a newer release (e.g. setuptools-scm / PyPI versions) because the string in `__init__.py` was never updated.

## Changes

- Set `__version__` from `importlib.metadata.version("metapulsar")` so it always matches the installed distribution metadata.
- On `PackageNotFoundError` (e.g. running from a raw checkout without an install), fall back to `0.0.0`, consistent with `fallback_version` in `[tool.setuptools_scm]` in `pyproject.toml`.
- Add `tests/test_version.py` asserting `metapulsar.__version__ == importlib.metadata.version("metapulsar")` to prevent reintroducing a hard-coded version string.