### PR TITLE
Fix ECL and T2CMETHOD treatment when using consistent strategy

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -50,7 +50,7 @@ jobs:
         shell: bash
       - name: Run tests with pytest
         env:
-          PYTEST_ADDOPTS: -m "not requires_libstempo and not requires_ipta_data and not legacy_comparison"
+          PYTEST_ADDOPTS: -m "not requires_libstempo and not requires_ipta_data and not legacy_comparison and not requires_legacy"
         run: |
           pytest --cov=src/metapulsar --cov-report xml:coverage.xml
       - name: Upload coverage to Codecov

--- a/docs/METHOD_DESCRIPTION.md
+++ b/docs/METHOD_DESCRIPTION.md
@@ -20,7 +20,7 @@ MetaPulsar uses **PINT** and **Tempo2/libstempo** to parse/realize timing models
 * **consistent** (default): make consistent astrophysical timing‑model components across PTAs while preserving detector‑specific timing‑model terms;
 * **composite**: leave all `.par` files untouched and compose them as‑is (useful for diagnostics; everything remains PTA‑specific).
 
-### Step 1: Unit normalization and reference model
+### Step 1: Unit normalization
 
 MetaPulsar first ensures that all `.par` files are in the same time unit convention:
 
@@ -28,64 +28,14 @@ MetaPulsar first ensures that all `.par` files are in the same time unit convent
 
    * For PINT models MetaPulsar re‑emits the model in TDB;
    * For Tempo2 models MetaPulsar calls the `transform tdb` plugin (both paths are implemented).
-2. Align **EPHEM** and **CLOCK/CLK** keywords to those of a **reference PTA**. By default the reference is the first PTA in the (optionally user‑ordered) list; a convenience function can choose the PTA with the longest timespan. This keeps solar‑system ephemerides and clock standards coherent without altering the TOAs.
+
+If all inputs already share the same `UNITS`, no conversion is performed.
 
 **No TOA samples are modified** in this step or any subsequent step of this method.
 
-#### Convention of consistent strategy
-
-After unit conversion and before design-matrix assembly, MetaPulsar applies a
-gated convention regarding how to make timing models consistent. The policy
-uses the pattern: discover per-PTA state, compare PTAs/engines, and only act
-when heterogeneity matters.
-
-Layer A is always applied:
-
-1. align `EPHEM` to the reference PTA,
-2. align `CLOCK`/`CLK` to the reference PTA.
-
-Layer B is applied only when both PINT and tempo2 PTAs are present
-(cross-engine stack):
-
-1. ecliptic astrometry: set `ECL IERS2003`,
-2. remove active `T2CMETHOD TEMPO`,
-3. equatorial astrometry: remove active `ECL` and emit a warning about the
-   known residual few-ns parity floor for equatorial inputs.
-
-Layer C is applied only for single-engine, multi-PTA stacks:
-
-- **PINT-only:** if ecliptic `ECL` values differ (including missing vs present),
-  align to the reference `ECL`; if the reference omits `ECL`, default to
-  `IERS2010`.
-- **Tempo2-only:** if ecliptic `ECL` values differ, align to `IERS2003`; if
-  `T2CMETHOD` values differ, align to the reference PTA's `T2CMETHOD` (which
-  preserves `TEMPO` when already shared in the reference).
-
-No-op cases:
-
-- single PTA (no cross-PTA convention alignment needed),
-- multi-PTA single-engine stacks that are already homogeneous for the relevant
-  conventions.
-
-`UNITS` normalization remains handled by `_convert_units_if_needed`; convention
-harmonization does not force `UNITS`.
-
-For cross-engine parity motivation and validation context, see Luo et al. 2021,
-*ApJ* 911, 45, [doi:10.3847/1538-4357/abe62f](https://doi.org/10.3847/1538-4357/abe62f).
-This method description intentionally does not reproduce the full paper
-regression narrative.
-
-| Scenario | `T2CMETHOD TEMPO` | Ecliptic `ECL` |
-|----------|-------------------|----------------|
-| Single PTA, tempo2-only | Keep | Unchanged |
-| Multi PTA, tempo2-only | Align across PTAs; keep `TEMPO` if shared in reference | Align to `IERS2003` if heterogeneous |
-| Multi PTA, PINT-only | N/A | Align to reference or `IERS2010` if heterogeneous |
-| Multi PTA, PINT + tempo2 | Remove/neutralize | Force `IERS2003` |
-| Equatorial + cross-engine | Remove + warning | Strip `ECL` |
-
 ### Step 2: Merge astrophysical timing‑model components
 
-MetaPulsar merges selected **astrophysical** components across PTAs by **copying parameter values from the reference PTA** into the other `.par` files *for those components only*. The set of components is configurable and defaults to
+Within `ParameterManager._make_parameters_consistent`, MetaPulsar merges selected **astrophysical** components across PTAs by **copying parameter values from the reference PTA** into the other `.par` files *for those components only*. The reference PTA is chosen from the (optionally user‑ordered) PTA list; by default it is the first PTA, and a convenience function can select the PTA with the longest timespan. The set of components is configurable and defaults to
 
 * `astrometry` (RAJ/DECJ or ELONG/ELAT, proper motions, etc.),
 * `spindown` (F0, F1, …),
@@ -113,7 +63,60 @@ This choice keeps the deterministic dispersion expansion identical across PTAs w
 
 Terminology: in MetaPulsar we use the word consistent to describe model components or parameters that are common between data of different PTAs, and that we 'lock' together (i.e. they become the same parameters or model component).
 
-### Step 3: Build Enterprise pulsars and validate identity
+### Step 3: Make timing‑model conventions consistent
+
+Still inside `_make_parameters_consistent`, **after** the component merge (Step 2) and **before** the consistent `.par` strings are written, MetaPulsar calls `_apply_convention_harmonization`. The policy uses the pattern: discover per‑PTA state, compare PTAs/engines, and only act when heterogeneity matters.
+
+**Prerequisites.** The reference PTA must contain `EPHEM` and either `CLOCK` or `CLK`; harmonization raises if either is missing.
+
+**Astrometry guard.** If a parfile contains both equatorial and ecliptic astrometry parameters, `detect_astrometry_style` raises a `ValueError` (surfaced as `RuntimeError` by `_make_parameters_consistent`).
+
+Layer A is always applied:
+
+1. align `EPHEM` to the reference PTA,
+2. align `CLOCK`/`CLK` to the reference PTA.
+
+Layer B is applied only when both PINT and tempo2 PTAs are present
+(cross-engine stack):
+
+1. ecliptic astrometry: set `ECL IERS2003`,
+2. remove active `T2CMETHOD TEMPO` (only when the first token is `TEMPO`),
+3. equatorial astrometry: remove active `ECL` and emit a warning about the
+   known residual few-ns parity floor for equatorial inputs.
+
+Layer C is applied only for single-engine, multi-PTA stacks:
+
+- **PINT-only:** if ecliptic `ECL` values differ (including missing vs present),
+  align to the reference `ECL`; if the reference omits `ECL`, default to
+  `IERS2010`.
+- **Tempo2-only:** if ecliptic `ECL` values differ, align to `IERS2003`; if
+  `T2CMETHOD` values differ, align to the reference PTA's `T2CMETHOD` (which
+  preserves `TEMPO` when already shared in the reference).
+
+No-op cases:
+
+- single PTA: Layers B and C are skipped (Layer A still aligns `EPHEM` and
+  `CLOCK`/`CLK`, which is usually already true),
+- multi-PTA single-engine stacks that are already homogeneous for the relevant
+  conventions.
+
+`UNITS` normalization remains handled by `_convert_units_if_needed`; convention
+harmonization does not force `UNITS`.
+
+For cross-engine parity motivation and validation context, see Luo et al. 2021,
+*ApJ* 911, 45, [doi:10.3847/1538-4357/abe62f](https://doi.org/10.3847/1538-4357/abe62f).
+This method description intentionally does not reproduce the full paper
+regression narrative.
+
+| Scenario | `T2CMETHOD TEMPO` | Ecliptic `ECL` |
+|----------|-------------------|----------------|
+| Single PTA, tempo2-only | Keep | Unchanged |
+| Multi PTA, tempo2-only | Align across PTAs; keep `TEMPO` if shared in reference | Align to `IERS2003` if heterogeneous |
+| Multi PTA, PINT-only | N/A | Align to reference or `IERS2010` if heterogeneous |
+| Multi PTA, PINT + tempo2 | Remove/neutralize | Force `IERS2003` |
+| Equatorial + cross-engine | Remove + warning | Strip `ECL` |
+
+### Step 4: Build Enterprise pulsars and validate identity
 
 For each PTA MetaPulsar builds an Enterprise pulsar object:
 
@@ -122,7 +125,7 @@ For each PTA MetaPulsar builds an Enterprise pulsar object:
 
 MetaPulsar validates that all PTAs refer to the **same sky position** by converting names to a canonical **J‑name** derived from coordinates. “B‑vs‑J” selection is only for **display**—coordinate matching is authoritative.
 
-### Step 4: Parameter mapping (merged vs PTA‑specific)
+### Step 5: Parameter mapping (merged vs PTA‑specific)
 
 MetaPulsar now defines the **meta‑parameters** that the combined design matrix will use.
 
@@ -133,7 +136,7 @@ MetaPulsar now defines the **meta‑parameters** that the combined design matrix
 
 This mapping is produced by `ParameterManager.build_parameter_mappings()` and recorded as `fitparameters` (free) and `setparameters` (present) in the `MetaPulsar` object. It is **deterministic** given the input `.par` files and the selected consistent components.
 
-### Step 5: Concatenate TOAs and flags (no data edits)
+### Step 6: Concatenate TOAs and flags (no data edits)
 
 MetaPulsar concatenates the per‑PTA arrays into combined vectors:
 
@@ -142,7 +145,7 @@ MetaPulsar concatenates the per‑PTA arrays into combined vectors:
 
 Again, **no TOA value is altered**; this is a pure concatenation with bookkeeping.
 
-### Step 6: Construct the combined design matrix
+### Step 7: Construct the combined design matrix
 
 Let ( **P** ) be the set of meta‑parameters (columns to be fit). For each meta‑parameter ( q ∈ **P** ):
 
@@ -152,7 +155,7 @@ Let ( **P** ) be the set of meta‑parameters (columns to be fit). For each meta
 
 After assembly MetaPulsar performs a **non‑identifiability check**: any column whose absolute sum is numerically zero (no support in any rows) is dropped from the fit list. This avoids singular normal matrices and is reported via warnings (note: if a parameter has zero support, this indicates an error in the underlying data release. This happens in, e.g., IPTA-DR2 datasets).
 
-### Step 7: Planetary and positional metadata
+### Step 8: Planetary and positional metadata
 
 MetaPulsar adopts position vectors, SSB ephemerides, and related arrays directly from the underlying Enterprise objects and copies them into the combined structure row‑wise. This is bookkeeping only and does not alter any physical quantity.
 
@@ -174,13 +177,13 @@ Any re‑timing that yields the **same column space** of ( **M** ) produces the 
 
 * **Choice of consistent components.** The default choice `{astrometry, spindown, binary, dispersion}` fits most pulsars. For problematic sources one can drop a component from the consistent set; all parameters of that component then remain PTA‑specific.
 * **DM modeling.** Removing DMX in favor of {DM, DMEPOCH, DM1, DM2} makes the deterministic DM part uniform. Stochastic DM variations are handled entirely in the noise model (e.g., a DM GP) during inference.
-* **Nonlinear regimes.** If a pulsar resides in a regime where ( **M** ) varies rapidly with ( β₀ ) (high‑order binary models, poorly constrained orbital evolution), manual inspection is recommended. The factory allows a **composite** strategy (no merging model components) for such cases.
+* **Challenging timing models.** If a pulsar resides in a regime where ( **M** ) varies rapidly with ( β₀ ) (high‑order binary models, poorly constrained orbital evolution), manual inspection is recommended. For Pulsar Timing Array purposes this is typically not an important regime to take into account. Note that the factory allows a **composite** strategy (no merging model components) for such cases (aka: FrankenStat) that is slightly more forgiving in this regard.
 * **Name handling.** Pulsar identity is validated via **coordinates**. B‑ vs J‑name is a display convention only and does not enter any computation.
 * **Determinism and provenance.** Given the set of `.par`/`.tim` inputs, the chosen reference PTA, and the list of consistent components, the output is deterministic. The code can optionally write the **consistent** `.par` files it constructs for full auditability.
 
 ### Implementation details (reproducibility pointers)
 
-* **Factory and orchestration.** `MetaPulsarFactory.create_metapulsar(...)` loads `.par` content, validates the single‑pulsar grouping by coordinates, selects/accepts the reference PTA, and (for the **consistent** strategy) calls `ParameterManager.make_parfiles_consistent()` to emit consistent `.par` files (optionally to disk).
+* **Factory and orchestration.** `MetaPulsarFactory.create_metapulsar(...)` loads `.par` content, validates the single‑pulsar grouping by coordinates, selects/accepts the reference PTA, and (for the **consistent** strategy) calls `ParameterManager.make_parfiles_consistent()` to emit consistent `.par` files (optionally to disk). That method runs: parse → unit convert → `_make_parameters_consistent` (component merge, then convention harmonization) → write.
 * **Parameter discovery and aliasing.** `ParameterManager` uses PINT’s model metadata plus a lightweight alias resolver to collect the parameter sets by *component type* and to resolve name differences between PINT and Tempo2.
 * **Design‑matrix assembly.** `MetaPulsar` (a subclass of `enterprise.pulsar.BasePulsar`) builds `fitparameters`/`setparameters` from the mapping, concatenates the per‑PTA arrays, and assembles the combined `designmatrix` column‑by‑column—applying explicit unit corrections for astrometric columns where PINT and Tempo2 differ. A zero‑information column cull prevents singularities.
 * **Flags and metadata.** The combined flags include `pta`, `pta_dataset`, and `timing_package`. Planetary and positional arrays are copied row‑wise from the underlying Enterprise pulsars.
@@ -193,8 +196,8 @@ Any re‑timing that yields the **same column space** of ( **M** ) produces the 
 ### Minimal algorithm (for reference)
 
 1. **Parse & normalize units** for all PTAs (`UNITS → TDB` only when needed).
-2. **Harmonize conventions** with gated rules: always align `EPHEM`, `CLOCK/CLK`; apply cross-engine parity rules only when both PINT and tempo2 are present; otherwise apply single-engine multi-PTA alignment only when conventions are heterogeneous.
-3. **Make consistent** selected components by copying reference PTA values; **leave detector‑specific timing‑model parameters as PTA‑local**; for dispersion: remove DMX, set DM (free), set DMEPOCH (frozen), add DM1/DM2 (free, 0).
+2. **Make consistent** selected components by copying reference PTA values; **leave detector‑specific timing‑model parameters as PTA‑local**; for dispersion: remove DMX, set DM (free), set DMEPOCH (frozen), add DM1/DM2 (free, 0).
+3. **Harmonize conventions** with gated rules: always align `EPHEM`, `CLOCK/CLK`; apply cross-engine parity rules only when both PINT and tempo2 are present; otherwise apply single-engine multi-PTA alignment only when conventions are heterogeneous.
 4. **Instantiate** Enterprise pulsars (PINT or Tempo2 path). Validate same pulsar by coordinates.
 5. **Map parameters** into merged and PTA‑specific meta‑parameters (deterministic mapping).
 6. **Concatenate** per‑PTA arrays (TOAs, flags, etc.) without modification.
@@ -205,13 +208,12 @@ Any re‑timing that yields the **same column space** of ( **M** ) produces the 
 
 #### Notes
 
-* **Unit conversions and EPHEM/CLOCK alignment:** `ParameterManager._convert_units_if_needed`, `_convert_pint_to_tdb`, `_convert_tempo2_to_tdb`, and convention Layer A in `ParameterManager._apply_convention_harmonization`.
-* **Gated convention harmonization:** `ParameterManager._apply_convention_harmonization` and legacy `MetaParfiles.apply_parity_protocol`.
+* **Unit conversions:** `ParameterManager._convert_units_if_needed`, `_convert_pint_to_tdb`, `_convert_tempo2_to_tdb`.
+* **Component merge:** `_make_component_parameters_consistent`, `_handle_dm_special_cases`.
+* **Convention harmonization (Layers A/B/C):** `ParameterManager._apply_convention_harmonization` (called at the end of `_make_parameters_consistent`); legacy alias `_apply_parity_protocol`. Astrometry style detection: `detect_astrometry_style` in `pint_helpers.py`. Legacy mirror: `MetaParfiles.apply_parity_protocol` in `metapulsar.legacy`.
 * **Component discovery/aliasing:** `get_parameters_by_type_from_models`, `resolve_parameter_alias`, `check_component_available_in_model`.
-* **Dispersion handling:** `ParameterManager._handle_dm_special_cases` (remove DMX, set DM/DMEPOCH, add DM1/DM2).
 * **Detector‑specific timing‑model parameters remain local:** anything not in the consistent component set becomes PTA‑suffixed in `_add_pta_specific_parameter`.
 * **Phase offset exposure:** if `PHOFF` is absent MetaPulsar defines a meta‑parameter mapped to the canonical “Offset” column so that per‑dataset constant phase terms are explicit.
 * **Combined design matrix:** `MetaPulsar._build_design_matrix` (with unit corrections in `_convert_design_matrix_units`) and the zero‑information cull in `_remove_nonidentifiable_parameters`.
 * **Identity validation and naming:** `bj_name_from_pulsar` and coordinate‑based checks in `_validate_pulsar_consistency`.
 * **No TOA edits:** `MetaPulsar._combine_timing_data` concatenates; there are no writes or transforms of TOAs.
-

--- a/docs/METHOD_DESCRIPTION.md
+++ b/docs/METHOD_DESCRIPTION.md
@@ -32,6 +32,57 @@ MetaPulsar first ensures that all `.par` files are in the same time unit convent
 
 **No TOA samples are modified** in this step or any subsequent step of this method.
 
+#### Convention harmonization (gated, UNITS-like)
+
+After unit conversion and before design-matrix assembly, MetaPulsar applies a
+gated convention harmonization pass. The policy matches the same pattern as
+unit handling: discover per-PTA state, compare PTAs/engines, and only act when
+heterogeneity matters.
+
+Layer A is always applied:
+
+1. align `EPHEM` to the reference PTA,
+2. align `CLOCK`/`CLK` to the reference PTA.
+
+Layer B is applied only when both PINT and tempo2 PTAs are present
+(cross-engine stack):
+
+1. ecliptic astrometry: set `ECL IERS2003`,
+2. remove active `T2CMETHOD TEMPO`,
+3. equatorial astrometry: remove active `ECL` and emit a warning about the
+   known residual few-ns parity floor for equatorial inputs.
+
+Layer C is applied only for single-engine, multi-PTA stacks:
+
+- **PINT-only:** if ecliptic `ECL` values differ (including missing vs present),
+  align to the reference `ECL`; if the reference omits `ECL`, default to
+  `IERS2010`.
+- **Tempo2-only:** if ecliptic `ECL` values differ, align to `IERS2003`; if
+  `T2CMETHOD` values differ, align to the reference PTA's `T2CMETHOD` (which
+  preserves `TEMPO` when already shared in the reference).
+
+No-op cases:
+
+- single PTA (no cross-PTA convention alignment needed),
+- multi-PTA single-engine stacks that are already homogeneous for the relevant
+  conventions.
+
+`UNITS` normalization remains handled by `_convert_units_if_needed`; convention
+harmonization does not force `UNITS`.
+
+For cross-engine parity motivation and validation context, see Luo et al. 2021,
+*ApJ* 911, 45, [doi:10.3847/1538-4357/abe62f](https://doi.org/10.3847/1538-4357/abe62f).
+This method description intentionally does not reproduce the full paper
+regression narrative.
+
+| Scenario | `T2CMETHOD TEMPO` | Ecliptic `ECL` |
+|----------|-------------------|----------------|
+| Single PTA, tempo2-only | Keep | Unchanged |
+| Multi PTA, tempo2-only | Align across PTAs; keep `TEMPO` if shared in reference | Align to `IERS2003` if heterogeneous |
+| Multi PTA, PINT-only | N/A | Align to reference or `IERS2010` if heterogeneous |
+| Multi PTA, PINT + tempo2 | Remove/neutralize | Force `IERS2003` |
+| Equatorial + cross-engine | Remove + warning | Strip `ECL` |
+
 ### Step 2: Merge astrophysical timing‑model components
 
 MetaPulsar merges selected **astrophysical** components across PTAs by **copying parameter values from the reference PTA** into the other `.par` files *for those components only*. The set of components is configurable and defaults to
@@ -141,19 +192,21 @@ Any re‑timing that yields the **same column space** of ( **M** ) produces the 
 
 ### Minimal algorithm (for reference)
 
-1. **Parse & normalize units** for all PTAs (`UNITS → TDB`; align `EPHEM`, `CLOCK/CLK`).
-2. **Make consistent** selected components by copying reference PTA values; **leave detector‑specific timing‑model parameters as PTA‑local**; for dispersion: remove DMX, set DM (free), set DMEPOCH (frozen), add DM1/DM2 (free, 0).
-3. **Instantiate** Enterprise pulsars (PINT or Tempo2 path). Validate same pulsar by coordinates.
-4. **Map parameters** into merged and PTA‑specific meta‑parameters (deterministic mapping).
-5. **Concatenate** per‑PTA arrays (TOAs, flags, etc.) without modification.
-6. **Assemble** the combined design matrix column‑by‑column using the mapping, with explicit unit conversions; drop zero‑information columns.
-7. **Expose** a `MetaPulsar` object fully compatible with Enterprise/Discovery.
+1. **Parse & normalize units** for all PTAs (`UNITS → TDB` only when needed).
+2. **Harmonize conventions** with gated rules: always align `EPHEM`, `CLOCK/CLK`; apply cross-engine parity rules only when both PINT and tempo2 are present; otherwise apply single-engine multi-PTA alignment only when conventions are heterogeneous.
+3. **Make consistent** selected components by copying reference PTA values; **leave detector‑specific timing‑model parameters as PTA‑local**; for dispersion: remove DMX, set DM (free), set DMEPOCH (frozen), add DM1/DM2 (free, 0).
+4. **Instantiate** Enterprise pulsars (PINT or Tempo2 path). Validate same pulsar by coordinates.
+5. **Map parameters** into merged and PTA‑specific meta‑parameters (deterministic mapping).
+6. **Concatenate** per‑PTA arrays (TOAs, flags, etc.) without modification.
+7. **Assemble** the combined design matrix column‑by‑column using the mapping, with explicit unit conversions; drop zero‑information columns.
+8. **Expose** a `MetaPulsar` object fully compatible with Enterprise/Discovery.
 
 ---
 
 #### Notes
 
-* **Unit conversions and ephemeris/clock alignment:** `ParameterManager._convert_units_if_needed`, `_convert_pint_to_tdb`, `_convert_tempo2_to_tdb`, and the EPHEM/CLOCK block in `_make_parameters_consistent`.
+* **Unit conversions and EPHEM/CLOCK alignment:** `ParameterManager._convert_units_if_needed`, `_convert_pint_to_tdb`, `_convert_tempo2_to_tdb`, and convention Layer A in `ParameterManager._apply_convention_harmonization`.
+* **Gated convention harmonization:** `ParameterManager._apply_convention_harmonization` and legacy `MetaParfiles.apply_parity_protocol`.
 * **Component discovery/aliasing:** `get_parameters_by_type_from_models`, `resolve_parameter_alias`, `check_component_available_in_model`.
 * **Dispersion handling:** `ParameterManager._handle_dm_special_cases` (remove DMX, set DM/DMEPOCH, add DM1/DM2).
 * **Detector‑specific timing‑model parameters remain local:** anything not in the consistent component set becomes PTA‑suffixed in `_add_pta_specific_parameter`.

--- a/docs/METHOD_DESCRIPTION.md
+++ b/docs/METHOD_DESCRIPTION.md
@@ -2,7 +2,7 @@
 
 ### Problem statement and summary
 
-Given multiple public PTA data sets for the **same** pulsar—each consisting of a **timing model** (a `.par` file) and **times of arrival** (a `.tim` file)—MetaPulsar constructs a single “metapulsar” that can be analyzed with standard PTA likelihoods without first re‑deriving a common timing solution. The procedure **does not modify the TOAs**; it only organizes the **deterministic timing model** across PTAs, and then builds the **combined design matrix** and metadata needed by Enterprise/Discovery.
+Given multiple public PTA data sets for the **same** pulsar—each consisting of a **timing model** (a `.par` file) and **times of arrival** (a `.tim` file)—MetaPulsar constructs a single “metapulsar” that can be analyzed with standard PTA likelihoods without first manually re‑deriving a common timing solution. The procedure **does not modify the TOAs**; it only organizes the **deterministic timing model** across PTAs, and then builds the **combined design matrix** and metadata needed by Enterprise/Discovery.
 
 After analytic marginalization over timing‑model parameters, the likelihood depends on the **column space** of the design matrix ( **M** ) rather than on the specific nominal parameter values ( β₀ ). Our procedure guarantees that the relevant column space is the same as in a traditional manual combination, so it is **statistically equivalent** to a full re‑timing while being vastly simpler and deterministic.
 
@@ -32,12 +32,12 @@ MetaPulsar first ensures that all `.par` files are in the same time unit convent
 
 **No TOA samples are modified** in this step or any subsequent step of this method.
 
-#### Convention harmonization (gated, UNITS-like)
+#### Convention of consistent strategy
 
 After unit conversion and before design-matrix assembly, MetaPulsar applies a
-gated convention harmonization pass. The policy matches the same pattern as
-unit handling: discover per-PTA state, compare PTAs/engines, and only act when
-heterogeneity matters.
+gated convention regarding how to make timing models consistent. The policy
+uses the pattern: discover per-PTA state, compare PTAs/engines, and only act
+when heterogeneity matters.
 
 Layer A is always applied:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,4 +142,5 @@ markers = [
     "unit: marks tests as unit tests",
     "requires_libstempo: marks tests that need libstempo/Tempo2 available",
     "requires_ipta_data: marks tests that need IPTA data files present",
+    "requires_legacy: marks tests that need metapulsar.legacy installed",
 ]

--- a/src/metapulsar/parameter_manager.py
+++ b/src/metapulsar/parameter_manager.py
@@ -11,7 +11,7 @@ import tempfile
 import subprocess
 from pathlib import Path
 from io import StringIO
-from typing import Dict, List, Any, Tuple
+from typing import Dict, List, Any, Tuple, Optional, Set
 import logging
 
 from pint.models.model_builder import parse_parfile
@@ -39,6 +39,16 @@ class ParameterManager:
     - Resolving parameter aliases and availability
     - Working with both PINT and Tempo2 PTAs
     """
+
+    _EQUATORIAL_WARNING = (
+        "Equatorial astrometry detected. PINT/tempo2 parity after T2CMETHOD "
+        "harmonization is typically a few ns (about 6 ns on NG5 J1600), "
+        "slightly larger than ecliptic pars with full convention alignment "
+        "(about 1 ns on NG11 J1600). Reason: no explicit ECL obliquity "
+        "convention to harmonize; residual differences from ecliptic-frame "
+        "geometry entering delay terms may remain. For best parity, prefer "
+        "ecliptic coordinates in new timing solutions."
+    )
 
     def __init__(
         self,
@@ -276,7 +286,13 @@ class ParameterManager:
         except Exception as e:
             raise RuntimeError(f"PINT conversion failed: {e}") from e
 
-    def _align_parameter(self, parfile_dict, reference_dict, aliases):
+    def _align_parameter(
+        self,
+        parfile_dict: Dict[str, List[str]],
+        reference_dict: Dict[str, List[str]],
+        aliases,
+        required: bool = False,
+    ) -> bool:
         alias_list = [aliases] if isinstance(aliases, str) else list(aliases)
 
         # Grab the reference value from whichever alias the reference PTA used
@@ -286,10 +302,11 @@ class ParameterManager:
                 ref_key = alias
                 break
         if ref_key is None:
-            self.logger.error(
-                f"No alias from {alias_list} found in reference PTA {self.reference_pta}"
-            )
-            return
+            msg = f"No alias from {alias_list} found in reference PTA {self.reference_pta}"
+            if required:
+                raise ValueError(msg)
+            self.logger.error(msg)
+            return False
         ref_value = reference_dict[ref_key]
 
         # Keep only the first alias that already exists in this PTA; drop the rest
@@ -310,6 +327,225 @@ class ParameterManager:
 
         # Update the value in-place using the existing key
         parfile_dict[target_key] = ref_value
+        return True
+
+    def _is_t2cmethod_tempo(self, value: List[str]) -> bool:
+        if not value:
+            return False
+        first = value[0].split()[0].upper() if value[0].split() else ""
+        return first == "TEMPO"
+
+    def _normalize_timing_package(self, package: str) -> str:
+        normalized = (package or "pint").strip().lower()
+        if normalized == "libstempo":
+            return "tempo2"
+        return normalized
+
+    def _normalized_timing_packages(self) -> Set[str]:
+        return {
+            self._normalize_timing_package(self._get_timing_package(pta_name))
+            for pta_name in self.file_data
+        }
+
+    def _is_cross_engine_mix(self, normalized_packages: Set[str]) -> bool:
+        return {"pint", "tempo2"}.issubset(normalized_packages)
+
+    def _parse_ecl_value(self, parfile_dict: Dict[str, List[str]]) -> Optional[str]:
+        raw_value = parfile_dict.get("ECL")
+        if not raw_value:
+            return None
+        parts = raw_value[0].split() if raw_value[0] else []
+        if not parts:
+            return None
+        return parts[0].upper()
+
+    def _parse_t2cmethod_value(
+        self, parfile_dict: Dict[str, List[str]]
+    ) -> Optional[str]:
+        raw_value = parfile_dict.get("T2CMETHOD")
+        if not raw_value:
+            return None
+        parts = raw_value[0].split() if raw_value[0] else []
+        if not parts:
+            return None
+        return parts[0].upper()
+
+    def _collect_convention_states(
+        self, parfile_dicts: Dict[str, Dict[str, List[str]]]
+    ) -> Dict[str, Dict[str, Optional[str]]]:
+        states: Dict[str, Dict[str, Optional[str]]] = {}
+        for pta_name, parfile_dict in parfile_dicts.items():
+            states[pta_name] = {
+                "style": self._detect_astrometry_style(parfile_dict),
+                "ecl": self._parse_ecl_value(parfile_dict),
+                "t2cmethod": self._parse_t2cmethod_value(parfile_dict),
+                "package": self._normalize_timing_package(
+                    self._get_timing_package(pta_name)
+                ),
+            }
+        return states
+
+    def _detect_astrometry_style(self, parfile_dict: Dict[str, List[str]]) -> str:
+        has_equatorial = "RAJ" in parfile_dict and "DECJ" in parfile_dict
+        has_ecliptic = ("LAMBDA" in parfile_dict or "ELONG" in parfile_dict) and (
+            "BETA" in parfile_dict or "ELAT" in parfile_dict
+        )
+
+        if has_equatorial and has_ecliptic:
+            raise ValueError(
+                "Mixed astrometry detected (equatorial and ecliptic parameters present). "
+                "Refuse to harmonize ambiguous coordinate representation."
+            )
+        if has_ecliptic:
+            return "ecliptic"
+        if has_equatorial:
+            return "equatorial"
+        raise ValueError(
+            "Could not detect astrometry style. Expected either RAJ/DECJ or "
+            "LAMBDA/BETA (or ELONG/ELAT)."
+        )
+
+    def _apply_convention_harmonization(
+        self,
+        parfile_dicts: Dict[str, Dict[str, List[str]]],
+        reference_dict: Dict[str, List[str]],
+    ) -> None:
+        """Apply gated convention harmonization across consistent parfile dictionaries."""
+        # Required shared conventions must exist in reference model
+        self._align_parameter(reference_dict, reference_dict, "EPHEM", required=True)
+        self._align_parameter(
+            reference_dict, reference_dict, ["CLOCK", "CLK"], required=True
+        )
+
+        for parfile_dict in parfile_dicts.values():
+            self._align_parameter(parfile_dict, reference_dict, "EPHEM", required=True)
+            self._align_parameter(
+                parfile_dict, reference_dict, ["CLOCK", "CLK"], required=True
+            )
+
+        convention_states = self._collect_convention_states(parfile_dicts)
+        normalized_packages = self._normalized_timing_packages()
+        cross_engine = self._is_cross_engine_mix(normalized_packages)
+
+        if cross_engine:
+            for pta_name, parfile_dict in parfile_dicts.items():
+                actions: List[str] = []
+                style = convention_states[pta_name]["style"]
+
+                if style == "ecliptic":
+                    old_ecl = parfile_dict.get("ECL", ["(missing)"])[0]
+                    parfile_dict["ECL"] = ["IERS2003"]
+                    actions.append(f"set ECL=IERS2003 (was {old_ecl})")
+                else:
+                    if "ECL" in parfile_dict:
+                        old_ecl = parfile_dict.pop("ECL")
+                        actions.append(f"removed ECL ({old_ecl[0]})")
+                    self.logger.warning(f"[{pta_name}] {self._EQUATORIAL_WARNING}")
+                    actions.append("emitted equatorial warning")
+
+                if "T2CMETHOD" in parfile_dict and self._is_t2cmethod_tempo(
+                    parfile_dict["T2CMETHOD"]
+                ):
+                    old_t2c = parfile_dict.pop("T2CMETHOD")
+                    actions.append(f"removed T2CMETHOD ({old_t2c[0]})")
+
+                self.logger.info(
+                    f"PTA {pta_name}: convention harmonization applied "
+                    f"(reason=cross_engine_parity, style={style}); "
+                    f"actions: {', '.join(actions) if actions else 'none'}"
+                )
+            return
+
+        if len(parfile_dicts) == 1:
+            self.logger.info(
+                "Convention harmonization skipped (reason=single_pta_single_engine)"
+            )
+            return
+
+        if normalized_packages == {"pint"}:
+            ecliptic_ptas = [
+                pta_name
+                for pta_name, state in convention_states.items()
+                if state["style"] == "ecliptic"
+            ]
+            ecliptic_ecl_values = {
+                convention_states[pta_name]["ecl"] for pta_name in ecliptic_ptas
+            }
+
+            if len(ecliptic_ecl_values) <= 1:
+                self.logger.info(
+                    "Convention harmonization skipped (reason=homogeneous_ecl_single_engine_pint)"
+                )
+                return
+
+            reference_ecl = self._parse_ecl_value(reference_dict)
+            target_ecl = reference_ecl or "IERS2010"
+            for pta_name in ecliptic_ptas:
+                old_ecl = parfile_dicts[pta_name].get("ECL", ["(missing)"])[0]
+                parfile_dicts[pta_name]["ECL"] = [target_ecl]
+                self.logger.info(
+                    f"PTA {pta_name}: convention harmonization applied "
+                    f"(reason=pint_only_ecl_heterogeneous); set ECL={target_ecl} (was {old_ecl})"
+                )
+            return
+
+        if normalized_packages == {"tempo2"}:
+            ecliptic_ptas = [
+                pta_name
+                for pta_name, state in convention_states.items()
+                if state["style"] == "ecliptic"
+            ]
+            ecliptic_ecl_values = {
+                convention_states[pta_name]["ecl"] for pta_name in ecliptic_ptas
+            }
+            if len(ecliptic_ecl_values) > 1:
+                for pta_name in ecliptic_ptas:
+                    old_ecl = parfile_dicts[pta_name].get("ECL", ["(missing)"])[0]
+                    parfile_dicts[pta_name]["ECL"] = ["IERS2003"]
+                    self.logger.info(
+                        f"PTA {pta_name}: convention harmonization applied "
+                        f"(reason=tempo2_only_ecl_heterogeneous); "
+                        f"set ECL=IERS2003 (was {old_ecl})"
+                    )
+            else:
+                self.logger.info(
+                    "Convention harmonization skipped (reason=homogeneous_ecl_single_engine_tempo2)"
+                )
+
+            t2_values = {state["t2cmethod"] for state in convention_states.values()}
+            if len(t2_values) > 1:
+                if "T2CMETHOD" not in reference_dict:
+                    self.logger.info(
+                        "T2CMETHOD alignment skipped (reason=reference_missing_t2cmethod)"
+                    )
+                else:
+                    for pta_name, parfile_dict in parfile_dicts.items():
+                        self._align_parameter(
+                            parfile_dict, reference_dict, "T2CMETHOD", required=False
+                        )
+                        self.logger.info(
+                            f"PTA {pta_name}: convention harmonization applied "
+                            "(reason=tempo2_only_t2cmethod_heterogeneous); "
+                            f"set T2CMETHOD={parfile_dict['T2CMETHOD'][0]}"
+                        )
+            else:
+                self.logger.info(
+                    "T2CMETHOD alignment skipped (reason=homogeneous_t2cmethod_single_engine_tempo2)"
+                )
+            return
+
+        self.logger.info(
+            "Convention harmonization skipped "
+            f"(reason=unsupported_single_engine_packages:{sorted(normalized_packages)})"
+        )
+
+    def _apply_parity_protocol(
+        self,
+        parfile_dicts: Dict[str, Dict[str, List[str]]],
+        reference_dict: Dict[str, List[str]],
+    ) -> None:
+        """Backward-compatible alias for convention harmonization."""
+        self._apply_convention_harmonization(parfile_dicts, reference_dict)
 
     def _make_parameters_consistent(
         self, parfile_data: Dict[str, str]
@@ -396,23 +632,12 @@ class ParameterManager:
                     dmx_params_map,
                 )
 
-        # Always align CLOCK and EPHEM parameters
-        for pta_name, parfile_dict in parfile_dicts.items():
-            self._align_parameter(parfile_dict, reference_dict, "EPHEM")
-            self._align_parameter(parfile_dict, reference_dict, ["CLOCK", "CLK"])
-        #    parfile_dict["EPHEM"] = reference_dict["EPHEM"]
-        #    if "CLOCK" in reference_dict:
-        #        parfile_dict["CLOCK"] = reference_dict["CLOCK"]
-        #        if "CLK" in parfile_dict:
-        #            parfile_dict.pop("CLK")
-        #    elif "CLK" in reference_dict:
-        #        parfile_dict["CLK"] = reference_dict["CLK"]
-        #        if "CLOCK" in parfile_dict:
-        #            parfile_dict.pop("CLOCK")
-        #    else:
-        #        self.logger.error(
-        #            f"No CLOCK or CLK parameter found in reference PTA {self.reference_pta}"
-        #        )
+        # Harmonize conventions with gated cross/single engine rules
+        try:
+            self._apply_convention_harmonization(parfile_dicts, reference_dict)
+        except ValueError as e:
+            self.logger.error(f"Convention harmonization failed: {e}")
+            raise RuntimeError(f"Convention harmonization failed: {e}") from e
 
         # Convert back to par file strings
         consistent_parfiles = {}

--- a/src/metapulsar/parameter_manager.py
+++ b/src/metapulsar/parameter_manager.py
@@ -25,6 +25,7 @@ from .pint_helpers import (
     get_parameter_identifiability_from_model,
     dict_to_parfile_string,
     parse_parameter_using_pint,
+    detect_astrometry_style,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ class ParameterManager:
 
     _EQUATORIAL_WARNING = (
         "Equatorial astrometry detected. PINT/tempo2 parity after T2CMETHOD "
-        "harmonization is typically a few ns (about 6 ns on NG5 J1600), "
+        "modification is typically a few ns (about 6 ns on NG5 J1600), "
         "slightly larger than ecliptic pars with full convention alignment "
         "(about 1 ns on NG11 J1600). Reason: no explicit ECL obliquity "
         "convention to harmonize; residual differences from ecliptic-frame "
@@ -376,7 +377,7 @@ class ParameterManager:
         states: Dict[str, Dict[str, Optional[str]]] = {}
         for pta_name, parfile_dict in parfile_dicts.items():
             states[pta_name] = {
-                "style": self._detect_astrometry_style(parfile_dict),
+                "style": detect_astrometry_style(parfile_dict),
                 "ecl": self._parse_ecl_value(parfile_dict),
                 "t2cmethod": self._parse_t2cmethod_value(parfile_dict),
                 "package": self._normalize_timing_package(
@@ -384,26 +385,6 @@ class ParameterManager:
                 ),
             }
         return states
-
-    def _detect_astrometry_style(self, parfile_dict: Dict[str, List[str]]) -> str:
-        has_equatorial = "RAJ" in parfile_dict and "DECJ" in parfile_dict
-        has_ecliptic = ("LAMBDA" in parfile_dict or "ELONG" in parfile_dict) and (
-            "BETA" in parfile_dict or "ELAT" in parfile_dict
-        )
-
-        if has_equatorial and has_ecliptic:
-            raise ValueError(
-                "Mixed astrometry detected (equatorial and ecliptic parameters present). "
-                "Refuse to harmonize ambiguous coordinate representation."
-            )
-        if has_ecliptic:
-            return "ecliptic"
-        if has_equatorial:
-            return "equatorial"
-        raise ValueError(
-            "Could not detect astrometry style. Expected either RAJ/DECJ or "
-            "LAMBDA/BETA (or ELONG/ELAT)."
-        )
 
     def _apply_convention_harmonization(
         self,
@@ -632,7 +613,7 @@ class ParameterManager:
                     dmx_params_map,
                 )
 
-        # Harmonize conventions with gated cross/single engine rules
+        # Make conventions consistent with gated cross/single engine rules
         try:
             self._apply_convention_harmonization(parfile_dicts, reference_dict)
         except ValueError as e:

--- a/src/metapulsar/pint_helpers.py
+++ b/src/metapulsar/pint_helpers.py
@@ -629,6 +629,7 @@ def temporary_pn_tim_from_par_tim_tempo2(
         par_tmp.write_text(parfile_text, encoding="utf-8")
         cmd = [
             "tempo2",
+            "-nofit",
             "-f",
             str(par_tmp),
             str(tim_path),

--- a/src/metapulsar/pint_helpers.py
+++ b/src/metapulsar/pint_helpers.py
@@ -121,6 +121,65 @@ def get_aliases_for_parameter(canonical_param: str) -> List[str]:
         return [canonical_param]
 
 
+def _parfile_alias_value_present(parfile_dict: Dict[str, Any], alias: str) -> bool:
+    """Return True if alias is present in a parfile dict with a non-empty value."""
+    if alias not in parfile_dict:
+        return False
+    value = parfile_dict[alias]
+    if value is None:
+        return False
+    if isinstance(value, list):
+        if not value:
+            return False
+        return bool(str(value[0]).strip())
+    return bool(str(value).strip())
+
+
+def has_parameter_alias(parfile_dict: Dict[str, Any], canonical_param: str) -> bool:
+    """Return True if any PINT alias for canonical_param is present and non-empty."""
+    return any(
+        _parfile_alias_value_present(parfile_dict, alias)
+        for alias in get_aliases_for_parameter(canonical_param)
+    )
+
+
+def has_equatorial_astrometry(parfile_dict: Dict[str, Any]) -> bool:
+    """Return True if equatorial astrometry parameters are present (via PINT aliases)."""
+    return has_parameter_alias(parfile_dict, "RAJ") and has_parameter_alias(
+        parfile_dict, "DECJ"
+    )
+
+
+def has_ecliptic_astrometry(parfile_dict: Dict[str, Any]) -> bool:
+    """Return True if ecliptic astrometry parameters are present (via PINT aliases)."""
+    return has_parameter_alias(parfile_dict, "ELONG") and has_parameter_alias(
+        parfile_dict, "ELAT"
+    )
+
+
+def detect_astrometry_style(parfile_dict: Dict[str, Any]) -> str:
+    """Detect whether a parfile uses equatorial or ecliptic astrometry.
+
+    Uses PINT's alias map rather than hard-coded parameter names.
+    """
+    has_equatorial = has_equatorial_astrometry(parfile_dict)
+    has_ecliptic = has_ecliptic_astrometry(parfile_dict)
+
+    if has_equatorial and has_ecliptic:
+        raise ValueError(
+            "Mixed astrometry detected (equatorial and ecliptic parameters present). "
+            "Refuse to make ambiguous coordinate representation consistent."
+        )
+    if has_ecliptic:
+        return "ecliptic"
+    if has_equatorial:
+        return "equatorial"
+    raise ValueError(
+        "Could not detect astrometry style. Expected either RAJ/DECJ or "
+        "LAMBDA/BETA (or ELONG/ELAT)."
+    )
+
+
 def clear_all_components_cache():
     """Clear the AllComponents cache.
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,10 +24,8 @@ def ipta_dr3_dir(data_dir):
 
 @pytest.fixture(scope="session")
 def legacy_module():
-    """Import and return the legacy module."""
-    from metapulsar.legacy import metapulsar
-
-    return metapulsar
+    """Import and return the legacy module (skip if not installed)."""
+    return pytest.importorskip("metapulsar.legacy.metapulsar")
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -160,15 +160,18 @@ C 55000.0 123.456 0.001 1234.5 1234.5
             data_release["base_dir"] = str(temp_dir)
             data_release["par_pattern"] = "J0030+0451.par"
 
-            # This should raise Tempo2Error because the par file is empty and causes libstempo toas() to fail
+            # This should raise Tempo2Error when libstempo processes the consistent par/tim pair
             with pytest.raises(Tempo2Error):
                 # Create file_data format for the test (list format)
-                # Provide minimal valid parfile content with coordinates for coordinate discovery
+                # par_content must include EPHEM/CLOCK for convention harmonization; on-disk par is empty
                 minimal_parfile_content = """RAJ 00:30:27.4
 DECJ 04:51:39.7
 F0 123.456
 DM 13.299 1 0.001
 PEPOCH 55000
+EPHEM DE421
+CLOCK TT(TAI)
+UNITS TDB
 """
                 file_data = {
                     "epta_dr1_v2_2": [
@@ -214,15 +217,18 @@ C 55000.0 123.456 0.001 1234.5 1234.5
             data_release["base_dir"] = str(temp_dir)
             data_release["par_pattern"] = "J0030+0451.par"
 
-            # This should raise Tempo2Error because the par file is corrupted and causes libstempo toas() to fail
+            # This should raise Tempo2Error when libstempo processes the consistent par/tim pair
             with pytest.raises(Tempo2Error):
                 # Create file_data format for the test (list format)
-                # Provide valid parfile content for coordinate discovery, but the actual file is corrupted
+                # par_content must include EPHEM/CLOCK for convention harmonization; on-disk par is corrupted
                 valid_parfile_content = """RAJ 00:30:27.4
 DECJ 04:51:39.7
 F0 123.456
 DM 13.299 1 0.001
 PEPOCH 55000
+EPHEM DE421
+CLOCK TT(TAI)
+UNITS TDB
 """
                 file_data = {
                     "epta_dr1_v2_2": [

--- a/tests/integration/test_legacy_comparison.py
+++ b/tests/integration/test_legacy_comparison.py
@@ -2,6 +2,7 @@
 
 import pytest
 import numpy as np
+from pathlib import Path
 from metapulsar import (
     FileDiscoveryService,
     get_pulsar_names_from_file_data,
@@ -12,6 +13,59 @@ from metapulsar import (
 @pytest.mark.integration
 class TestLegacyComparison:
     """Test comparison between legacy and new implementations."""
+
+    def _read_par_content(self, par_content):
+        if not isinstance(par_content, str):
+            return str(par_content)
+        if "\n" in par_content:
+            return par_content
+        maybe_path = Path(par_content)
+        if maybe_path.exists():
+            return maybe_path.read_text(encoding="utf-8")
+        return par_content
+
+    def _assert_protocol_harmonized(
+        self, par_content: str, label: str, engine_mix: bool
+    ):
+        text = self._read_par_content(par_content)
+        active_lines = []
+        for raw in text.splitlines():
+            line = raw.strip()
+            if line and not line.startswith("#"):
+                active_lines.append(line)
+
+        keys = {}
+        for line in active_lines:
+            parts = line.split()
+            if not parts:
+                continue
+            key = parts[0].upper()
+            keys[key] = parts[1:]
+
+        if engine_mix:
+            # Cross-engine harmonization should neutralize active TEMPO mode.
+            if "T2CMETHOD" in keys and keys["T2CMETHOD"]:
+                assert (
+                    keys["T2CMETHOD"][0].upper() != "TEMPO"
+                ), f"{label}: active T2CMETHOD TEMPO found after harmonization"
+
+        has_equatorial = "RAJ" in keys and "DECJ" in keys
+        has_ecliptic = ("LAMBDA" in keys or "ELONG" in keys) and (
+            "BETA" in keys or "ELAT" in keys
+        )
+        assert not (
+            has_equatorial and has_ecliptic
+        ), f"{label}: mixed astrometry detected after harmonization"
+
+        if has_ecliptic and engine_mix:
+            assert "ECL" in keys, f"{label}: expected ECL for ecliptic astrometry"
+            assert (
+                keys["ECL"][0].upper() == "IERS2003"
+            ), f"{label}: expected ECL IERS2003, found {' '.join(keys['ECL'])}"
+        elif has_equatorial and engine_mix:
+            assert (
+                "ECL" not in keys
+            ), f"{label}: equatorial astrometry should not include active ECL"
 
     def _prepare_legacy_input_files(
         self, pulsar_name, pta_data_releases, available_data_sets
@@ -680,6 +734,8 @@ class TestLegacyComparison:
                     }
                 )
 
+            engine_mix = len({entry["package"] for entry in input_files}) > 1
+
             # Create both implementations
             legacy_mp = legacy_module.create_metapulsar(input_files)
 
@@ -709,6 +765,13 @@ class TestLegacyComparison:
             new_par_content = getattr(new_mp, "intermediate_par_content", None)
 
             if legacy_par_content and new_par_content:
+                self._assert_protocol_harmonized(
+                    legacy_par_content, "legacy", engine_mix=engine_mix
+                )
+                self._assert_protocol_harmonized(
+                    new_par_content, "new", engine_mix=engine_mix
+                )
+
                 # Parse par files and compare key parameters
                 from pint.models import get_model
 

--- a/tests/integration/test_legacy_comparison.py
+++ b/tests/integration/test_legacy_comparison.py
@@ -11,6 +11,7 @@ from metapulsar import (
 
 
 @pytest.mark.integration
+@pytest.mark.requires_legacy
 class TestLegacyComparison:
     """Test comparison between legacy and new implementations."""
 

--- a/tests/test_legacy_metaparfiles_protocol.py
+++ b/tests/test_legacy_metaparfiles_protocol.py
@@ -5,7 +5,10 @@ from unittest.mock import patch
 
 import pytest
 
-from metapulsar.legacy.metapulsar import MetaParfiles
+_legacy_metapulsar = pytest.importorskip("metapulsar.legacy.metapulsar")
+MetaParfiles = _legacy_metapulsar.MetaParfiles
+
+pytestmark = pytest.mark.requires_legacy
 
 
 def _build_input(pta: str, par_content: str, package: str = "tempo2") -> dict:

--- a/tests/test_legacy_metaparfiles_protocol.py
+++ b/tests/test_legacy_metaparfiles_protocol.py
@@ -1,0 +1,281 @@
+"""Unit tests for legacy MetaParfiles parity protocol harmonization."""
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from metapulsar.legacy.metapulsar import MetaParfiles
+
+
+def _build_input(pta: str, par_content: str, package: str = "tempo2") -> dict:
+    return {
+        "pta": pta,
+        "parfile": StringIO(par_content),
+        "package": package,
+    }
+
+
+def test_legacy_parity_protocol_cross_engine_ecliptic_harmonization():
+    par1 = (
+        "PSR J1600-3053\n"
+        "LAMBDA 244.347\n"
+        "BETA -10.07\n"
+        "ECL IERS2010\n"
+        "T2CMETHOD TEMPO\n"
+        "EPHEM DE436\n"
+        "CLOCK TT(BIPM2015)\n"
+        "UNITS TDB\n"
+    )
+    par2 = (
+        "PSR J1600-3053\n"
+        "LAMBDA 244.347\n"
+        "BETA -10.07\n"
+        "ECL IERS2010\n"
+        "T2CMETHOD TEMPO\n"
+        "EPHEM DE440\n"
+        "CLK TT(BIPM2021)\n"
+        "UNITS TDB\n"
+    )
+    mpf = MetaParfiles(
+        parfiles=[
+            _build_input("epta", par1, package="tempo2"),
+            _build_input("ppta", par2, package="pint"),
+        ],
+        merge_astrometry=False,
+        merge_spin=False,
+        merge_binary=False,
+        merge_dm=False,
+        convert=True,
+    )
+
+    for pfd in mpf._parfiles:
+        pd = pfd["pardict_conv"]
+        assert pd["UNITS"] == ["TDB"]
+        assert pd["ECL"] == ["IERS2003"]
+        assert "T2CMETHOD" not in pd
+        assert pd["EPHEM"] == ["DE436"]
+        assert pd["CLOCK"] == ["TT(BIPM2015)"]
+        assert "CLK" not in pd
+
+
+def test_legacy_parity_protocol_equatorial_warning_and_no_ecl():
+    par1 = (
+        "PSR J1857+0943\n"
+        "RAJ 18:57:36.3937\n"
+        "DECJ +09:43:17.291\n"
+        "ECL IERS2010\n"
+        "T2CMETHOD TEMPO\n"
+        "EPHEM DE440\n"
+        "CLOCK TT(BIPM2021)\n"
+        "UNITS TDB\n"
+    )
+    par2 = (
+        "PSR J1857+0943\n"
+        "RAJ 18:57:36.3937\n"
+        "DECJ +09:43:17.291\n"
+        "T2CMETHOD TEMPO\n"
+        "EPHEM DE436\n"
+        "CLK TT(BIPM2015)\n"
+        "UNITS TDB\n"
+    )
+
+    with patch("metapulsar.legacy.metapulsar.logger.warning") as mock_warning:
+        mpf = MetaParfiles(
+            parfiles=[
+                _build_input("epta", par1, package="tempo2"),
+                _build_input("ppta", par2, package="pint"),
+            ],
+            merge_astrometry=False,
+            merge_spin=False,
+            merge_binary=False,
+            merge_dm=False,
+            convert=True,
+        )
+
+    for pfd in mpf._parfiles:
+        pd = pfd["pardict_conv"]
+        assert pd["UNITS"] == ["TDB"]
+        assert "ECL" not in pd
+        assert "T2CMETHOD" not in pd
+    assert mock_warning.call_count == 2
+
+
+def test_legacy_parity_protocol_pint_only_aligns_ecl_to_reference_or_default():
+    par1 = (
+        "PSR J1600-3053\n"
+        "LAMBDA 244.347\n"
+        "BETA -10.07\n"
+        "ECL IERS2010\n"
+        "EPHEM DE440\n"
+        "CLOCK TT(BIPM2021)\n"
+        "UNITS TDB\n"
+    )
+    par2 = (
+        "PSR J1600-3053\n"
+        "LAMBDA 244.347\n"
+        "BETA -10.07\n"
+        "EPHEM DE436\n"
+        "CLK TT(BIPM2015)\n"
+        "UNITS TDB\n"
+    )
+
+    mpf = MetaParfiles(
+        parfiles=[
+            _build_input("epta", par1, package="pint"),
+            _build_input("ppta", par2, package="pint"),
+        ],
+        merge_astrometry=False,
+        merge_spin=False,
+        merge_binary=False,
+        merge_dm=False,
+        convert=True,
+    )
+
+    for pfd in mpf._parfiles:
+        pd = pfd["pardict_conv"]
+        assert pd["ECL"] == ["IERS2010"]
+        assert "T2CMETHOD" not in pd
+
+
+def test_legacy_parity_protocol_tempo2_only_preserves_shared_t2cmethod():
+    par1 = (
+        "PSR J1600-3053\n"
+        "LAMBDA 244.347\n"
+        "BETA -10.07\n"
+        "ECL IERS2010\n"
+        "T2CMETHOD TEMPO\n"
+        "EPHEM DE436\n"
+        "CLOCK TT(BIPM2015)\n"
+        "UNITS TDB\n"
+    )
+    par2 = (
+        "PSR J1600-3053\n"
+        "LAMBDA 244.347\n"
+        "BETA -10.07\n"
+        "ECL IERS2010\n"
+        "T2CMETHOD TEMPO\n"
+        "EPHEM DE440\n"
+        "CLK TT(BIPM2021)\n"
+        "UNITS TDB\n"
+    )
+    mpf = MetaParfiles(
+        parfiles=[
+            _build_input("epta", par1, package="tempo2"),
+            _build_input("ppta", par2, package="tempo2"),
+        ],
+        merge_astrometry=False,
+        merge_spin=False,
+        merge_binary=False,
+        merge_dm=False,
+        convert=True,
+    )
+
+    for pfd in mpf._parfiles:
+        pd = pfd["pardict_conv"]
+        assert pd["ECL"] == ["IERS2010"]
+        assert pd["T2CMETHOD"] == ["TEMPO"]
+
+
+def test_legacy_parity_protocol_tempo2_only_aligns_heterogeneous_conventions():
+    par1 = (
+        "PSR J1600-3053\n"
+        "LAMBDA 244.347\n"
+        "BETA -10.07\n"
+        "ECL IERS2010\n"
+        "T2CMETHOD TEMPO\n"
+        "EPHEM DE436\n"
+        "CLOCK TT(BIPM2015)\n"
+        "UNITS TDB\n"
+    )
+    par2 = (
+        "PSR J1600-3053\n"
+        "LAMBDA 244.347\n"
+        "BETA -10.07\n"
+        "ECL IERS2003\n"
+        "T2CMETHOD IAU2000B\n"
+        "EPHEM DE440\n"
+        "CLK TT(BIPM2021)\n"
+        "UNITS TDB\n"
+    )
+    mpf = MetaParfiles(
+        parfiles=[
+            _build_input("epta", par1, package="tempo2"),
+            _build_input("ppta", par2, package="tempo2"),
+        ],
+        merge_astrometry=False,
+        merge_spin=False,
+        merge_binary=False,
+        merge_dm=False,
+        convert=True,
+    )
+
+    for pfd in mpf._parfiles:
+        pd = pfd["pardict_conv"]
+        assert pd["ECL"] == ["IERS2003"]
+        assert pd["T2CMETHOD"] == ["TEMPO"]
+
+
+def test_legacy_parity_protocol_single_pta_tempo2_keeps_t2cmethod():
+    par = (
+        "PSR J1600-3053\n"
+        "LAMBDA 244.347\n"
+        "BETA -10.07\n"
+        "ECL IERS2010\n"
+        "T2CMETHOD TEMPO\n"
+        "EPHEM DE436\n"
+        "CLOCK TT(BIPM2015)\n"
+        "UNITS TDB\n"
+    )
+    mpf = MetaParfiles(
+        parfiles=[_build_input("epta", par, package="tempo2")],
+        merge_astrometry=False,
+        merge_spin=False,
+        merge_binary=False,
+        merge_dm=False,
+        convert=True,
+    )
+    pd = mpf._parfiles[0]["pardict_conv"]
+    assert pd["T2CMETHOD"] == ["TEMPO"]
+    assert pd["ECL"] == ["IERS2010"]
+
+
+def test_legacy_parity_protocol_mixed_astrometry_raises():
+    par = (
+        "PSR J1857+0943\n"
+        "RAJ 18:57:36.3937\n"
+        "DECJ +09:43:17.291\n"
+        "LAMBDA 244.347\n"
+        "BETA -10.07\n"
+        "EPHEM DE440\n"
+        "CLOCK TT(BIPM2021)\n"
+        "UNITS TDB\n"
+    )
+    with pytest.raises(ValueError, match="Mixed astrometry detected"):
+        MetaParfiles(
+            parfiles=[_build_input("epta", par, package="tempo2")],
+            merge_astrometry=False,
+            merge_spin=False,
+            merge_binary=False,
+            merge_dm=False,
+            convert=True,
+        )
+
+
+def test_legacy_parity_protocol_missing_reference_clock_raises():
+    par = (
+        "PSR J1857+0943\n"
+        "RAJ 18:57:36.3937\n"
+        "DECJ +09:43:17.291\n"
+        "EPHEM DE440\n"
+        "UNITS TDB\n"
+    )
+    with pytest.raises(ValueError, match="CLOCK/CLK"):
+        MetaParfiles(
+            parfiles=[_build_input("epta", par, package="tempo2")],
+            merge_astrometry=False,
+            merge_spin=False,
+            merge_binary=False,
+            merge_dm=False,
+            convert=True,
+        )

--- a/tests/test_parameter_manager.py
+++ b/tests/test_parameter_manager.py
@@ -437,3 +437,316 @@ UNITS TDB
                 add_dm_derivatives=True,
                 dmx_params_map={"EPTA": [], "PPTA": []},
             )
+
+    def test_apply_convention_harmonization_cross_engine_ecliptic(self):
+        """Cross-engine ecliptic pars force ECL IERS2003 and remove T2CMETHOD TEMPO."""
+        file_data = {
+            "EPTA": {
+                "timing_package": "tempo2",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "LAMBDA 244.347\n"
+                    "BETA -10.07\n"
+                    "ECL IERS2010\n"
+                    "T2CMETHOD TEMPO\n"
+                    "EPHEM DE436\n"
+                    "CLOCK TT(BIPM2015)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+            "PPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "LAMBDA 244.347\n"
+                    "BETA -10.07\n"
+                    "ECL IERS2010\n"
+                    "T2CMETHOD TEMPO\n"
+                    "EPHEM DE440\n"
+                    "CLK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        parameter_manager._apply_convention_harmonization(parfile_dicts, reference_dict)
+
+        for _, pd in parfile_dicts.items():
+            assert pd["UNITS"] == ["TDB"]
+            assert pd["ECL"] == ["IERS2003"]
+            assert "T2CMETHOD" not in pd
+            assert pd["EPHEM"] == ["DE436"]
+            clock_value = pd["CLOCK"] if "CLOCK" in pd else pd["CLK"]
+            assert clock_value == ["TT(BIPM2015)"]
+
+    def test_apply_convention_harmonization_cross_engine_equatorial_warning_and_no_ecl(
+        self,
+    ):
+        """Cross-engine equatorial pars emit warning and should not carry ECL."""
+        file_data = {
+            "EPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1857+0943\n"
+                    "RAJ 18:57:36.3937\n"
+                    "DECJ +09:43:17.291\n"
+                    "ECL IERS2010\n"
+                    "T2CMETHOD TEMPO\n"
+                    "EPHEM DE440\n"
+                    "CLOCK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+            "PPTA": {
+                "timing_package": "tempo2",
+                "par_content": (
+                    "PSR J1857+0943\n"
+                    "RAJ 18:57:36.3937\n"
+                    "DECJ +09:43:17.291\n"
+                    "T2CMETHOD TEMPO\n"
+                    "EPHEM DE436\n"
+                    "CLK TT(BIPM2015)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        with patch.object(parameter_manager.logger, "warning") as mock_warning:
+            parameter_manager._apply_convention_harmonization(
+                parfile_dicts, reference_dict
+            )
+
+        for _, pd in parfile_dicts.items():
+            assert pd["UNITS"] == ["TDB"]
+            assert "ECL" not in pd
+            assert "T2CMETHOD" not in pd
+        assert mock_warning.call_count == 2
+
+    def test_apply_convention_harmonization_pint_only_aligns_missing_ecl_to_iers2010(
+        self,
+    ):
+        file_data = {
+            "EPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "LAMBDA 244.347\n"
+                    "BETA -10.07\n"
+                    "ECL IERS2010\n"
+                    "EPHEM DE440\n"
+                    "CLOCK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+            "PPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "LAMBDA 244.347\n"
+                    "BETA -10.07\n"
+                    "EPHEM DE436\n"
+                    "CLK TT(BIPM2015)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        with patch.object(parameter_manager.logger, "warning") as mock_warning:
+            parameter_manager._apply_convention_harmonization(
+                parfile_dicts, reference_dict
+            )
+
+        assert parfile_dicts["EPTA"]["ECL"] == ["IERS2010"]
+        assert parfile_dicts["PPTA"]["ECL"] == ["IERS2010"]
+        assert "T2CMETHOD" not in parfile_dicts["EPTA"]
+        assert "T2CMETHOD" not in parfile_dicts["PPTA"]
+        assert mock_warning.call_count == 0
+
+    def test_apply_convention_harmonization_tempo2_only_preserves_shared_t2cmethod(
+        self,
+    ):
+        file_data = {
+            "EPTA": {
+                "timing_package": "tempo2",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "LAMBDA 244.347\n"
+                    "BETA -10.07\n"
+                    "ECL IERS2010\n"
+                    "T2CMETHOD TEMPO\n"
+                    "EPHEM DE436\n"
+                    "CLOCK TT(BIPM2015)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+            "PPTA": {
+                "timing_package": "tempo2",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "LAMBDA 244.347\n"
+                    "BETA -10.07\n"
+                    "ECL IERS2010\n"
+                    "T2CMETHOD TEMPO\n"
+                    "EPHEM DE440\n"
+                    "CLK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        parameter_manager._apply_convention_harmonization(parfile_dicts, reference_dict)
+
+        for pd in parfile_dicts.values():
+            assert pd["ECL"] == ["IERS2010"]
+            assert pd["T2CMETHOD"] == ["TEMPO"]
+
+    def test_apply_convention_harmonization_tempo2_only_aligns_heterogeneous_conventions(
+        self,
+    ):
+        file_data = {
+            "EPTA": {
+                "timing_package": "tempo2",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "LAMBDA 244.347\n"
+                    "BETA -10.07\n"
+                    "ECL IERS2010\n"
+                    "T2CMETHOD TEMPO\n"
+                    "EPHEM DE436\n"
+                    "CLOCK TT(BIPM2015)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+            "PPTA": {
+                "timing_package": "tempo2",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "LAMBDA 244.347\n"
+                    "BETA -10.07\n"
+                    "ECL IERS2003\n"
+                    "T2CMETHOD IAU2000B\n"
+                    "EPHEM DE440\n"
+                    "CLK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        parameter_manager._apply_convention_harmonization(parfile_dicts, reference_dict)
+
+        assert parfile_dicts["EPTA"]["ECL"] == ["IERS2003"]
+        assert parfile_dicts["PPTA"]["ECL"] == ["IERS2003"]
+        assert parfile_dicts["EPTA"]["T2CMETHOD"] == ["TEMPO"]
+        assert parfile_dicts["PPTA"]["T2CMETHOD"] == ["TEMPO"]
+
+    def test_apply_convention_harmonization_single_pta_tempo2_noop_for_t2cmethod(self):
+        file_data = {
+            "EPTA": {
+                "timing_package": "tempo2",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "LAMBDA 244.347\n"
+                    "BETA -10.07\n"
+                    "ECL IERS2010\n"
+                    "T2CMETHOD TEMPO\n"
+                    "EPHEM DE436\n"
+                    "CLOCK TT(BIPM2015)\n"
+                    "UNITS TDB\n"
+                ),
+            }
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        parameter_manager._apply_convention_harmonization(parfile_dicts, reference_dict)
+
+        assert parfile_dicts["EPTA"]["T2CMETHOD"] == ["TEMPO"]
+        assert parfile_dicts["EPTA"]["ECL"] == ["IERS2010"]
+
+    def test_apply_convention_harmonization_mixed_astrometry_raises(self):
+        """Mixed ecliptic/equatorial astrometry should fail fast."""
+        file_data = {
+            "EPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1857+0943\n"
+                    "RAJ 18:57:36.3937\n"
+                    "DECJ +09:43:17.291\n"
+                    "LAMBDA 244.347\n"
+                    "BETA -10.07\n"
+                    "EPHEM DE440\n"
+                    "CLOCK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            }
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        with pytest.raises(ValueError, match="Mixed astrometry detected"):
+            parameter_manager._apply_convention_harmonization(
+                parfile_dicts, reference_dict
+            )
+
+    def test_apply_convention_harmonization_missing_reference_clock_raises(self):
+        """Reference parfile must contain CLOCK or CLK."""
+        file_data = {
+            "EPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1857+0943\n"
+                    "RAJ 18:57:36.3937\n"
+                    "DECJ +09:43:17.291\n"
+                    "EPHEM DE440\n"
+                    "UNITS TDB\n"
+                ),
+            }
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        with pytest.raises(ValueError, match="CLOCK'.*CLK"):
+            parameter_manager._apply_convention_harmonization(
+                parfile_dicts, reference_dict
+            )
+
+    def test_apply_convention_harmonization_missing_reference_ephem_raises(self):
+        """Reference parfile must contain EPHEM."""
+        file_data = {
+            "EPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1857+0943\n"
+                    "RAJ 18:57:36.3937\n"
+                    "DECJ +09:43:17.291\n"
+                    "CLOCK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            }
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        with pytest.raises(ValueError, match="EPHEM"):
+            parameter_manager._apply_convention_harmonization(
+                parfile_dicts, reference_dict
+            )

--- a/tests/test_parameter_manager.py
+++ b/tests/test_parameter_manager.py
@@ -705,6 +705,41 @@ UNITS TDB
                 parfile_dicts, reference_dict
             )
 
+    def test_apply_convention_harmonization_pint_only_elong_elat_aliases(self):
+        file_data = {
+            "EPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "ELONG 244.347\n"
+                    "ELAT -10.07\n"
+                    "ECL IERS2010\n"
+                    "EPHEM DE440\n"
+                    "CLOCK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+            "PPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "ELONG 244.347\n"
+                    "ELAT -10.07\n"
+                    "EPHEM DE436\n"
+                    "CLK TT(BIPM2015)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        parameter_manager._apply_convention_harmonization(parfile_dicts, reference_dict)
+
+        assert parfile_dicts["EPTA"]["ECL"] == ["IERS2010"]
+        assert parfile_dicts["PPTA"]["ECL"] == ["IERS2010"]
+
     def test_apply_convention_harmonization_missing_reference_clock_raises(self):
         """Reference parfile must contain CLOCK or CLK."""
         file_data = {

--- a/tests/test_pint_helpers.py
+++ b/tests/test_pint_helpers.py
@@ -1,6 +1,7 @@
 """Unit tests for PINT helper functions."""
 
 import pytest
+from pathlib import Path
 from unittest.mock import Mock, patch
 from metapulsar.pint_helpers import (
     check_component_available_in_model,
@@ -666,3 +667,31 @@ class TestAstrometryStyleHelpers:
         }
         with pytest.raises(ValueError, match="Mixed astrometry detected"):
             detect_astrometry_style(parfile_dict)
+
+
+class TestTemporaryPnTimFromParTimTempo2:
+    """Test tempo2 subprocess pulse-number helper."""
+
+    def test_add_pulse_number_uses_nofit(self, tmp_path):
+        from metapulsar.pint_helpers import temporary_pn_tim_from_par_tim_tempo2
+
+        par_text = (
+            "PSR J0030+0451\nF0 205.5307\nF1 0\nRAJ 00:30:27.428\nDECJ +04:51:39.71\n"
+        )
+        tim_path = tmp_path / "test.tim"
+        tim_path.write_text("FORMAT 1\nMODE 1\n", encoding="utf-8")
+
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            cwd = Path(kwargs["cwd"])
+            (cwd / "withpn.tim").write_text("FORMAT 1\nMODE 1\n", encoding="utf-8")
+
+        with patch("metapulsar.pint_helpers.subprocess.run", side_effect=fake_run):
+            with temporary_pn_tim_from_par_tim_tempo2(par_text, tim_path) as pn_tim:
+                assert Path(pn_tim).exists()
+
+        assert captured_cmd[0] == "tempo2"
+        assert "-nofit" in captured_cmd
+        assert captured_cmd.index("-nofit") < captured_cmd.index("-f")

--- a/tests/test_pint_helpers.py
+++ b/tests/test_pint_helpers.py
@@ -624,3 +624,45 @@ T0 55000.0 1
             # Should still call ModelBuilder
             mock_builder.assert_called_once()
             assert result == mock_model
+
+
+class TestAstrometryStyleHelpers:
+    """Test alias-driven astrometry style detection helpers."""
+
+    def test_has_parameter_alias_accepts_pint_aliases(self):
+        from metapulsar.pint_helpers import has_parameter_alias
+
+        parfile_dict = {"LAMBDA": ["244.347"], "BETA": ["-10.07"]}
+        assert has_parameter_alias(parfile_dict, "ELONG")
+        assert has_parameter_alias(parfile_dict, "ELAT")
+        assert not has_parameter_alias(parfile_dict, "RAJ")
+
+    def test_detect_astrometry_style_equatorial_aliases(self):
+        from metapulsar.pint_helpers import detect_astrometry_style
+
+        parfile_dict = {
+            "RA": ["18:57:36.3937"],
+            "DEC": ["+09:43:17.291"],
+        }
+        assert detect_astrometry_style(parfile_dict) == "equatorial"
+
+    def test_detect_astrometry_style_ecliptic_aliases(self):
+        from metapulsar.pint_helpers import detect_astrometry_style
+
+        parfile_dict = {
+            "ELONG": ["244.347"],
+            "ELAT": ["-10.07"],
+        }
+        assert detect_astrometry_style(parfile_dict) == "ecliptic"
+
+    def test_detect_astrometry_style_mixed_raises(self):
+        from metapulsar.pint_helpers import detect_astrometry_style
+
+        parfile_dict = {
+            "RAJ": ["18:57:36.3937"],
+            "DECJ": ["+09:43:17.291"],
+            "LAMBDA": ["244.347"],
+            "BETA": ["-10.07"],
+        }
+        with pytest.raises(ValueError, match="Mixed astrometry detected"):
+            detect_astrometry_style(parfile_dict)


### PR DESCRIPTION
This fixes #19 

### Summary

Introduces a **convention harmonization** pass in `ParameterManager.make_parfiles_consistent()` so MetaPulsar can reconcile `ECL`, `T2CMETHOD`, and cross-engine astrometric conventions — not just `UNITS`, `EPHEM`, and `CLOCK`/`CLK`.

The pass is **gated** (like unit conversion): discover per-PTA convention state, compare across PTAs/engines, and mutate parfiles only when heterogeneity requires it.

### What was missing before

On `main`, consistent parfile preparation stopped after:

- `UNITS` normalization (`_convert_units_if_needed`)
- `EPHEM` / `CLOCK`/`CLK` alignment inside `_make_parameters_consistent`

There was no handling of `ECL`, `T2CMETHOD`, equatorial vs ecliptic astrometry conventions, or PINT/tempo2 cross-engine parity rules.

### What this PR adds

**`ParameterManager._apply_convention_harmonization()`** — orchestrates:

| Layer | When | Actions |
|-------|------|---------|
| A | Always | Align `EPHEM`, `CLOCK`/`CLK` to reference |
| B | PINT + tempo2 both present | Ecliptic → `ECL IERS2003`; neutralize `T2CMETHOD TEMPO`; equatorial → strip `ECL` + warning |
| C | Single-engine, multi-PTA | PINT-only `ECL` alignment (reference or `IERS2010`); tempo2-only heterogeneous `ECL`/`T2CMETHOD` alignment |
| — | Single PTA or homogeneous single-engine | No-op |

Helper methods: timing-package normalization (`libstempo` → `tempo2`), astrometry-style detection, convention state collection, and normalized parsing of `ECL`/`T2CMETHOD` values.

**Documentation:** new “Convention harmonization” subsection in `docs/METHOD_DESCRIPTION.md` with the decision table and Luo et al. 2021 citation.

**Tests:**

- `tests/test_parameter_manager.py` — cross-engine, PINT-only, tempo2-only, single-PTA no-op, and error cases
- `tests/test_legacy_metaparfiles_protocol.py` — protocol coverage via legacy `MetaParfiles` conversion flow
- `tests/integration/test_legacy_comparison.py` — `_assert_protocol_harmonized(..., engine_mix=...)` applies strict parity checks only for mixed-engine inputs

### Example outcomes

- **EPTA (tempo2) + NANOGrav (PINT), ecliptic:** both get `ECL IERS2003`; active `T2CMETHOD TEMPO` removed
- **Two PINT PTAs, one missing `ECL`:** both aligned to reference `IERS2010`
- **Two tempo2 PTAs, both `T2CMETHOD TEMPO`:** preserved (no unnecessary mutation)
- **Single tempo2 PTA with `T2CMETHOD TEMPO`:** unchanged

### Test plan

- [x] `pytest tests/test_parameter_manager.py tests/test_legacy_metaparfiles_protocol.py`
- [x] `pytest tests/integration/test_legacy_comparison.py -k intermediate_par_file_consistency`
- [x] `make fast`

### Notes

- `combination_strategy="composite"` is unchanged.
- Commit: `da1769f4` on `feature/pint-tempo2-par-equivalence`.