### PR TITLE
feat: explicit pulse-number modes for consistent PTA merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ print(f"Number of TOAs: {len(metapulsar.toas)}")
 print(f"PTA names: {list(metapulsar._pulsars.keys())}")
 ```
 
+### Pulse-number tracking (`use_pulse_numbers`)
+
+When combining PTAs with `combination_strategy="consistent"`, merged par files can
+break per-PTA phase coherence. Pulse-number tracking preserves phase connectivity
+via `-pn` flags and `TRACK -2` on the timing model.
+
+Pass a **string** mode to `create_metapulsar` (default `"yes"`). Booleans are no
+longer accepted.
+
+| Mode | Behavior |
+|------|----------|
+| `"no"` | Ignore pulse numbers; no `TRACK -2` override (Tempo2). |
+| `"yes"` | Reuse complete `-pn` on all TOAs; otherwise re-derive from original `par` + `tim`; warn on mixed partial `-pn`. |
+| `"reuse"` | Same as `"yes"` when complete; warn and re-derive when `-pn` is missing or incomplete. |
+| `"overwrite"` | Always re-derive `-pn` from the original coherent `par` + `tim`. |
+
+Migration: replace `use_pulse_numbers=True` with `"yes"` and `False` with `"no"`.
+
 ## Documentation
 
 - **[Interactive Tutorial](examples/notebooks/using_metapulsar.ipynb)** - Complete usage guide with examples

--- a/src/metapulsar/__init__.py
+++ b/src/metapulsar/__init__.py
@@ -46,7 +46,7 @@ from .mockpulsar import (
     create_mock_flags,
     validate_mock_data,
 )
-from .tim_file_analyzer import TimFileAnalyzer
+from .tim_file_analyzer import TimFileAnalyzer, TimMetadata
 from .selection_utils import create_staggered_selection
 
 # Exceptions
@@ -73,6 +73,7 @@ __all__ = [
     "create_mock_flags",
     "validate_mock_data",
     "TimFileAnalyzer",
+    "TimMetadata",
     "create_staggered_selection",
     "PINTDiscoveryError",
     # Convenience functions

--- a/src/metapulsar/file_discovery_service.py
+++ b/src/metapulsar/file_discovery_service.py
@@ -5,10 +5,12 @@ It is completely independent - NO external dependencies on PINT, libstempo, or o
 Uses only regex patterns for file matching and pattern extraction.
 """
 
-from typing import Dict, List, Any, Union, Tuple
+from typing import Dict, List, Any, Union
 from pathlib import Path
 import re
 from loguru import logger
+
+from .tim_file_analyzer import TimFileAnalyzer, TimMetadata
 
 __all__ = [
     "FileDiscoveryService",
@@ -142,6 +144,7 @@ class FileDiscoveryService:
         self.data_releases = pta_data_releases or PTA_DATA_RELEASES.copy()
         self.verbose = verbose
         self.logger = logger
+        self._tim_analyzer = TimFileAnalyzer()
 
     def discover_patterns_in_data_release(self, data_release_name: str) -> List[str]:
         """Discover all file patterns in a single data release using regex.
@@ -197,7 +200,7 @@ class FileDiscoveryService:
 
         Returns:
             Dictionary mapping data release names to lists of enriched file dictionaries
-            Format: {data_release_name: [{'par': parfile_path, 'tim': timfile_path, 'timing_package': 'pint', 'timespan_days': 1000.0}, ...]}
+            Format: {data_release_name: [{'par': parfile_path, 'tim': timfile_path, 'timing_package': 'pint', 'tim_metadata': TimMetadata(...)}, ...]}
         """
         if data_release_names is None:
             data_release_names = self.list_data_releases()
@@ -387,18 +390,14 @@ class FileDiscoveryService:
         # Step 3: Match par and tim files by canonical pulsar name
         for pulsar_name in par_files_by_pulsar:
             if pulsar_name in tim_files_by_pulsar:
-                # Calculate timespan and TOA count for this data release/pulsar combination
-                timespan, toa_count = self._calculate_timespan_and_count_from_tim_file(
-                    tim_files_by_pulsar[pulsar_name]
-                )
+                tim_metadata = self._get_tim_metadata(tim_files_by_pulsar[pulsar_name])
 
                 file_pairs.append(
                     {
                         "par": par_files_by_pulsar[pulsar_name],
                         "tim": tim_files_by_pulsar[pulsar_name],
                         "timing_package": data_release["timing_package"],
-                        "timespan_days": timespan,
-                        "toa_count": toa_count,
+                        "tim_metadata": tim_metadata,
                         "par_content": par_files_by_pulsar[pulsar_name].read_text(
                             encoding="utf-8"
                         ),
@@ -407,27 +406,24 @@ class FileDiscoveryService:
 
         return file_pairs
 
-    def _calculate_timespan_and_count_from_tim_file(
-        self, tim_file_path: Path
-    ) -> Tuple[float, int]:
-        """Calculate timespan and TOA count from TIM file using TimFileAnalyzer.
-
-        Args:
-            tim_file_path: Path to the TIM file
-
-        Returns:
-            Tuple of (timespan_in_days, toa_count)
-        """
+    def _get_tim_metadata(self, tim_file_path: Path) -> TimMetadata:
+        """Extract unified TIM metadata using the shared analyzer cache."""
         try:
-            from .tim_file_analyzer import TimFileAnalyzer
-
-            analyzer = TimFileAnalyzer()
-            return analyzer._get_timespan_and_count(tim_file_path)
+            return self._tim_analyzer.get_tim_metadata(tim_file_path)
         except Exception as e:
             self.logger.warning(
-                f"Could not calculate timespan and count for {tim_file_path}: {e}"
+                f"Could not parse TIM metadata for {tim_file_path}: {e}"
             )
-            return 0.0, 0
+            return TimMetadata(
+                toa_count=0,
+                mjd_min=None,
+                mjd_max=None,
+                timespan_days=0.0,
+                pn_with_count=0,
+                pn_without_count=0,
+                pn_status="none",
+                parse_warnings=(f"metadata extraction failed: {e}",),
+            )
 
 
 # Convenience function for easy access

--- a/src/metapulsar/metapulsar_factory.py
+++ b/src/metapulsar/metapulsar_factory.py
@@ -29,9 +29,12 @@ except ImportError:
 # Import sandbox for robust libstempo usage
 from .sandbox_tempo2 import tempopulsar
 from .pint_helpers import (
-    temporary_pn_tim_from_par_tim_pint,
-    temporary_pn_tim_from_par_tim_tempo2,
+    PulseNumberMode,
+    ensure_pint_track_minus_2,
+    pulse_number_tracking_enabled,
+    resolved_tim_for_pulse_numbers,
     temporary_par_with_track_minus_2,
+    validate_pulse_number_mode,
 )
 
 # Default components for consistent combination strategy
@@ -119,7 +122,7 @@ class MetaPulsarFactory:
         combine_components: List[str] = DEFAULT_COMBINE_COMPONENTS,
         add_dm_derivatives: bool = True,
         parfile_output_dir: Path = None,
-        use_pulse_numbers: bool = True,
+        use_pulse_numbers: str = "yes",
     ) -> MetaPulsar:
         """Create MetaPulsar using specified combination strategy.
 
@@ -134,6 +137,16 @@ class MetaPulsarFactory:
             add_dm_derivatives: Whether to ensure DM1, DM2 are present in all par files (for consistent strategy)
             parfile_output_dir: Directory to save consistent par files (for consistent strategy only).
                 If None, par files are not saved to disk.
+            use_pulse_numbers: Pulse-number mode (string only; default ``"yes"``):
+
+                - ``"no"``: ignore pulse numbers; no ``TRACK -2`` override (Tempo2).
+                - ``"yes"``: reuse complete ``-pn`` on all TOAs, else re-derive from
+                  original coherent ``par`` + ``tim``; warn on mixed partial ``-pn``.
+                - ``"reuse"``: same as ``"yes"`` when complete; warn and re-derive when
+                  incomplete or missing ``-pn``.
+                - ``"overwrite"``: always re-derive ``-pn`` from original ``par`` + ``tim``.
+
+                Booleans are rejected. Map legacy ``True`` → ``"yes"``, ``False`` → ``"no"``.
 
         Returns:
             MetaPulsar object
@@ -143,6 +156,7 @@ class MetaPulsarFactory:
             RuntimeError: If Enterprise Pulsar creation fails
         """
         self.logger.info(f"Creating MetaPulsar using {combination_strategy} strategy")
+        pulse_mode = validate_pulse_number_mode(use_pulse_numbers)
 
         # 1. Ensure parfile content is loaded
         validated_data = self._ensure_parfile_content(file_data)
@@ -212,7 +226,7 @@ class MetaPulsarFactory:
         pulsars = self._create_pulsar_objects(
             file_pairs=file_pairs,
             file_data=single_file_data,
-            use_pulse_numbers=use_pulse_numbers,
+            use_pulse_numbers=pulse_mode,
         )
 
         return MetaPulsar(
@@ -369,7 +383,7 @@ class MetaPulsarFactory:
         combine_components: List[str] = DEFAULT_COMBINE_COMPONENTS,
         add_dm_derivatives: bool = True,
         parfile_output_dir: Path = None,
-        use_pulse_numbers: bool = True,
+        use_pulse_numbers: str = "yes",
     ) -> Dict[str, MetaPulsar]:
         """Create MetaPulsars for all available pulsars using file data.
 
@@ -396,6 +410,7 @@ class MetaPulsarFactory:
         metapulsars = {}
 
         self.logger.info(f"Creating MetaPulsars for {len(pulsar_groups)} pulsars")
+        pulse_mode = validate_pulse_number_mode(use_pulse_numbers)
 
         for pulsar_name, pulsar_file_data in pulsar_groups.items():
             try:
@@ -413,7 +428,7 @@ class MetaPulsarFactory:
                     combine_components=combine_components,
                     add_dm_derivatives=add_dm_derivatives,
                     parfile_output_dir=parfile_output_dir,
-                    use_pulse_numbers=use_pulse_numbers,
+                    use_pulse_numbers=pulse_mode,
                 )
 
                 # Canonical name is automatically calculated from pulsar data
@@ -576,7 +591,7 @@ class MetaPulsarFactory:
         self,
         file_pairs: Dict[str, Tuple[Path, Path]],
         file_data: Dict[str, Dict[str, Any]],
-        use_pulse_numbers: bool = True,
+        use_pulse_numbers: PulseNumberMode = "yes",
     ) -> Dict[str, Any]:
         """Create PINT/Tempo2 objects from file pairs using file data.
 
@@ -584,16 +599,18 @@ class MetaPulsarFactory:
             file_pairs: Dictionary mapping PTA names to (parfile, timfile) tuples
             file_data: Dictionary mapping PTA names to file dictionaries
                       Contains timing_package info from FileDiscoveryService
-            use_pulse_numbers: Whether to derive and use pulse numbers from original par+tim
+            use_pulse_numbers: Pulse-number mode (``no``, ``yes``, ``reuse``, ``overwrite``)
 
         Returns:
             Dictionary mapping PTA names to PINT/Tempo2 objects
         """
         pulsar_objects = {}
+        track_pn = pulse_number_tracking_enabled(use_pulse_numbers)
 
         for pta_name, (parfile, timfile) in file_pairs.items():
             # Get timing package info from file data
             timing_package = file_data[pta_name]["timing_package"]
+            original_par_text = file_data[pta_name]["par_content"]
 
             try:
                 if timing_package == "pint":
@@ -601,44 +618,45 @@ class MetaPulsarFactory:
                     if get_model_and_toas is None:
                         raise RuntimeError("PINT not available for PINT creation")
 
-                    if use_pulse_numbers:
-                        original_par_text = file_data[pta_name]["par_content"]
-                        with temporary_pn_tim_from_par_tim_pint(
-                            original_par_text, timfile
-                        ) as pn_tim_path:
-                            model, toas = get_model_and_toas(
-                                str(parfile),
-                                str(pn_tim_path),
-                                planets=True,
-                                allow_T2=True,
-                            )
-                    else:
+                    with resolved_tim_for_pulse_numbers(
+                        use_pulse_numbers,
+                        original_par_text,
+                        timfile,
+                        derive_backend="pint",
+                    ) as tim_path:
                         model, toas = get_model_and_toas(
-                            str(parfile), str(timfile), planets=True, allow_T2=True
+                            str(parfile),
+                            tim_path,
+                            planets=True,
+                            allow_T2=True,
                         )
+                        if track_pn:
+                            ensure_pint_track_minus_2(model)
                     pulsar_objects[pta_name] = (model, toas)
 
                 else:  # tempo2
                     # Create Tempo2 object using sandbox
-                    if use_pulse_numbers:
-                        original_par_text = file_data[pta_name]["par_content"]
-                        with (
-                            temporary_pn_tim_from_par_tim_tempo2(
-                                original_par_text, timfile
-                            ) as pn_tim_path,
-                            temporary_par_with_track_minus_2(
+                    with resolved_tim_for_pulse_numbers(
+                        use_pulse_numbers,
+                        original_par_text,
+                        timfile,
+                        derive_backend="tempo2",
+                    ) as tim_path:
+                        if track_pn:
+                            with temporary_par_with_track_minus_2(
                                 Path(parfile).read_text(encoding="utf-8")
-                            ) as par_for_tempo2,
-                        ):
+                            ) as par_for_tempo2:
+                                t2_psr = tempopulsar(
+                                    parfile=str(par_for_tempo2),
+                                    timfile=tim_path,
+                                    dofit=False,
+                                )
+                        else:
                             t2_psr = tempopulsar(
-                                parfile=str(par_for_tempo2),
-                                timfile=str(pn_tim_path),
+                                parfile=str(parfile),
+                                timfile=tim_path,
                                 dofit=False,
                             )
-                    else:
-                        t2_psr = tempopulsar(
-                            parfile=str(parfile), timfile=str(timfile), dofit=False
-                        )
                     pulsar_objects[pta_name] = t2_psr
 
                 self.logger.debug(f"Created {timing_package} object for {pta_name}")
@@ -770,7 +788,7 @@ def create_metapulsar(
     combine_components: List[str] = DEFAULT_COMBINE_COMPONENTS,
     add_dm_derivatives: bool = True,
     parfile_output_dir: Path = None,
-    use_pulse_numbers: bool = True,
+    use_pulse_numbers: str = "yes",
 ) -> MetaPulsar:
     """Create MetaPulsar using specified combination strategy.
 
@@ -785,6 +803,8 @@ def create_metapulsar(
         add_dm_derivatives: Whether to ensure DM1, DM2 are present in all par files (for consistent strategy)
         parfile_output_dir: Directory to save consistent par files (for consistent strategy only).
             If None, par files are not saved to disk.
+        use_pulse_numbers: Pulse-number mode: ``"no"``, ``"yes"`` (default), ``"reuse"``,
+            or ``"overwrite"``. See ``MetaPulsarFactory.create_metapulsar`` for semantics.
 
     Returns:
         MetaPulsar object
@@ -812,7 +832,7 @@ def create_all_metapulsars(
     combine_components: List[str] = DEFAULT_COMBINE_COMPONENTS,
     add_dm_derivatives: bool = True,
     parfile_output_dir: Path = None,
-    use_pulse_numbers: bool = True,
+    use_pulse_numbers: str = "yes",
 ) -> Dict[str, MetaPulsar]:
     """Create MetaPulsars for all available pulsars using file data.
 
@@ -824,6 +844,8 @@ def create_all_metapulsars(
         add_dm_derivatives: Whether to ensure DM1, DM2 are present
         parfile_output_dir: Directory to save consistent par files (for consistent strategy only).
             If None, par files are not saved to disk. Creates subdirectories for each pulsar.
+        use_pulse_numbers: Pulse-number mode passed to each ``create_metapulsar`` call
+            (``"no"``, ``"yes"``, ``"reuse"``, or ``"overwrite"``; default ``"yes"``).
 
     Returns:
         Dictionary mapping pulsar names to MetaPulsar objects

--- a/src/metapulsar/metapulsar_factory.py
+++ b/src/metapulsar/metapulsar_factory.py
@@ -28,6 +28,7 @@ except ImportError:
 
 # Import sandbox for robust libstempo usage
 from .sandbox_tempo2 import tempopulsar
+from .tim_file_analyzer import TimFileAnalyzer, TimMetadata
 from .pint_helpers import (
     PulseNumberMode,
     ensure_pint_track_minus_2,
@@ -61,6 +62,7 @@ class MetaPulsarFactory:
         This factory only handles object creation from provided file paths.
         """
         self.logger = logger
+        self._tim_analyzer = TimFileAnalyzer()
         # ParameterManager will be instantiated as needed in methods
 
     def _ensure_parfile_content(
@@ -114,6 +116,27 @@ class MetaPulsarFactory:
 
         return validated_file_data
 
+    def _ensure_tim_metadata(
+        self, file_data: Dict[str, List[Dict[str, Any]]]
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Ensure each file dict has tim_metadata (populate at factory boundary)."""
+        enriched: Dict[str, List[Dict[str, Any]]] = {}
+        for pta_name, files in file_data.items():
+            enriched_files = []
+            for file_info in files:
+                updated = file_info.copy()
+                if "tim_metadata" not in updated:
+                    tim_path = updated.get("tim")
+                    if tim_path is not None:
+                        if isinstance(tim_path, str):
+                            tim_path = Path(tim_path)
+                        updated["tim_metadata"] = self._tim_analyzer.get_tim_metadata(
+                            tim_path
+                        )
+                enriched_files.append(updated)
+            enriched[pta_name] = enriched_files
+        return enriched
+
     def create_metapulsar(
         self,
         file_data: Dict[str, List[Dict[str, Any]]],
@@ -158,8 +181,9 @@ class MetaPulsarFactory:
         self.logger.info(f"Creating MetaPulsar using {combination_strategy} strategy")
         pulse_mode = validate_pulse_number_mode(use_pulse_numbers)
 
-        # 1. Ensure parfile content is loaded
+        # 1. Ensure parfile content and TIM metadata are loaded
         validated_data = self._ensure_parfile_content(file_data)
+        validated_data = self._ensure_tim_metadata(validated_data)
 
         # 2. Validate all files belong to same pulsar (coordinate-based)
         self._validate_single_pulsar_data(validated_data)
@@ -367,13 +391,49 @@ class MetaPulsarFactory:
                 continue
 
             # Get timespan for this PTA's files for this pulsar
-            timespan = max(f.get("timespan_days", 0) for f in files)
+            timespan = max(self._timespan_from_file_info(f) for f in files)
 
             if timespan > best_timespan:
                 best_timespan = timespan
                 best_pta = pta_name
 
         return best_pta or list(pulsar_file_data.keys())[0]
+
+    @staticmethod
+    def _timespan_from_file_info(file_info: Dict[str, Any]) -> float:
+        meta = file_info.get("tim_metadata")
+        if isinstance(meta, TimMetadata):
+            return meta.timespan_days
+        return 0.0
+
+    @staticmethod
+    def _toa_count_from_file_info(file_info: Dict[str, Any]) -> int:
+        meta = file_info.get("tim_metadata")
+        if isinstance(meta, TimMetadata):
+            return meta.toa_count
+        return 0
+
+    @staticmethod
+    def _pn_summary_from_files(files: List[Dict[str, Any]]) -> str:
+        total = 0
+        with_pn = 0
+        without_pn = 0
+        for file_info in files:
+            meta = file_info.get("tim_metadata")
+            if not isinstance(meta, TimMetadata):
+                continue
+            total += meta.toa_count
+            with_pn += meta.pn_with_count
+            without_pn += meta.pn_without_count
+        if total == 0:
+            return "pn=none (0/0)"
+        if with_pn == 0:
+            status = "none"
+        elif without_pn == 0:
+            status = "complete"
+        else:
+            status = "mixed"
+        return f"pn={status} ({with_pn}/{total})"
 
     def create_all_metapulsars(
         self,
@@ -399,8 +459,9 @@ class MetaPulsarFactory:
         Returns:
             Dictionary mapping pulsar names to MetaPulsar objects
         """
-        # 1. Ensure parfile content is loaded
+        # 1. Ensure parfile content and TIM metadata are loaded
         validated_data = self._ensure_parfile_content(file_data)
+        validated_data = self._ensure_tim_metadata(validated_data)
 
         # 2. Group files by pulsar with reference PTA ordering
         pulsar_groups = self._group_files_by_pulsar_with_ordering(
@@ -522,8 +583,9 @@ class MetaPulsarFactory:
 
                 # Note: file_data contains file paths per PTA, but pulsars are not yet matched between PTAs.
                 # The coordinate-based discovery groups files by pulsar using coordinate matching, not name matching.
-                # 1. Ensure parfile content is loaded
+                # 1. Ensure parfile content and TIM metadata are loaded
                 validated_data = self._ensure_parfile_content(file_data)
+                validated_data = self._ensure_tim_metadata(validated_data)
 
                 # 2. Group files by pulsar with reference PTA ordering
                 pulsar_groups = self._group_files_by_pulsar_with_ordering(
@@ -550,12 +612,23 @@ class MetaPulsarFactory:
                         if not files:
                             continue
 
-                        # Get timespan and TOA count for this PTA's files for this pulsar
-                        timespan_days = max(f.get("timespan_days", 0) for f in files)
+                        # Get timespan, TOA count, and pn coverage for this PTA
+                        timespan_days = max(
+                            self._timespan_from_file_info(f) for f in files
+                        )
                         timespan_years = timespan_days / 365.25
-                        toa_count = sum(f.get("toa_count", 0) for f in files)
+                        toa_count = sum(
+                            self._toa_count_from_file_info(f) for f in files
+                        )
+                        pn_summary = self._pn_summary_from_files(files)
                         pta_timespans.append(
-                            (pta_name, timespan_days, timespan_years, toa_count)
+                            (
+                                pta_name,
+                                timespan_days,
+                                timespan_years,
+                                toa_count,
+                                pn_summary,
+                            )
                         )
 
                     # Sort by timespan (longest first)
@@ -571,12 +644,15 @@ class MetaPulsarFactory:
                         timespan_days,
                         timespan_years,
                         toa_count,
+                        pn_summary,
                     ) in pta_timespans:
                         reference_indicator = (
                             " -- Reference PTA" if pta_name == reference_pta else ""
                         )
                         print(
-                            f"- {pta_name}: {timespan_days:.0f} days ({timespan_years:.1f} years, {toa_count} TOAs){reference_indicator}"
+                            f"- {pta_name}: {timespan_days:.0f} days "
+                            f"({timespan_years:.1f} years, {toa_count} TOAs, "
+                            f"{pn_summary}){reference_indicator}"
                         )
 
                     print()
@@ -611,6 +687,7 @@ class MetaPulsarFactory:
             # Get timing package info from file data
             timing_package = file_data[pta_name]["timing_package"]
             original_par_text = file_data[pta_name]["par_content"]
+            tim_metadata = file_data[pta_name].get("tim_metadata")
 
             try:
                 if timing_package == "pint":
@@ -623,6 +700,7 @@ class MetaPulsarFactory:
                         original_par_text,
                         timfile,
                         derive_backend="pint",
+                        tim_metadata=tim_metadata,
                     ) as tim_path:
                         model, toas = get_model_and_toas(
                             str(parfile),
@@ -641,6 +719,7 @@ class MetaPulsarFactory:
                         original_par_text,
                         timfile,
                         derive_backend="tempo2",
+                        tim_metadata=tim_metadata,
                     ) as tim_path:
                         if track_pn:
                             with temporary_par_with_track_minus_2(

--- a/src/metapulsar/pint_helpers.py
+++ b/src/metapulsar/pint_helpers.py
@@ -4,7 +4,7 @@ This module provides pure functions that encapsulate PINT-specific logic
 for parameter discovery, alias resolution, and model validation.
 """
 
-from typing import Dict, List, Tuple, Any, Iterator
+from typing import Dict, List, Tuple, Any, Iterator, Literal
 from functools import lru_cache
 from pint.models import TimingModel
 from pint.models.timing_model import AllComponents
@@ -15,7 +15,6 @@ import tempfile
 import subprocess
 from io import StringIO
 import numpy as np
-from pint.models.model_builder import parse_parfile
 
 
 class PINTDiscoveryError(Exception):
@@ -303,7 +302,6 @@ def create_pint_model(parfile_data) -> TimingModel:
         InvalidModelParameters,
         ComponentConflict,
     )
-    from io import StringIO
     from loguru import logger
 
     try:
@@ -508,9 +506,123 @@ def parse_parameter_using_pint(param_name: str, param_value) -> Tuple[Any, bool]
 # ----------------------- Pulse-number helper utilities ----------------------- #
 
 from pint.toa import get_TOAs, TOAs  # noqa: E402 (import after top-level defs)
+from loguru import logger as loguru_logger  # noqa: E402
+
+PulseNumberMode = Literal["no", "yes", "reuse", "overwrite"]
+PULSE_NUMBER_MODES: Tuple[str, ...] = ("no", "yes", "reuse", "overwrite")
+TimPulseNumberStatus = Literal["complete", "mixed", "none"]
 
 
-def ensure_pulse_numbers(toas: TOAs, model: TimingModel) -> TOAs:
+def validate_pulse_number_mode(value: object) -> PulseNumberMode:
+    """Validate and normalize use_pulse_numbers mode string."""
+    if not isinstance(value, str):
+        raise ValueError(
+            f"use_pulse_numbers must be one of {PULSE_NUMBER_MODES!r}, "
+            f"got {type(value).__name__}: {value!r}"
+        )
+    mode = value.strip().lower()
+    if mode not in PULSE_NUMBER_MODES:
+        raise ValueError(
+            f"use_pulse_numbers must be one of {PULSE_NUMBER_MODES!r}, got {value!r}"
+        )
+    return mode  # type: ignore[return-value]
+
+
+def pulse_number_tracking_enabled(mode: PulseNumberMode) -> bool:
+    return mode in ("yes", "reuse", "overwrite")
+
+
+def classify_tim_pulse_numbers(tim_path: Path) -> Tuple[TimPulseNumberStatus, int, int]:
+    """Classify -pn coverage on TOA lines in a .tim file.
+
+    Returns:
+        (status, n_with_pn, n_without_pn) where status is complete, mixed, or none.
+    """
+    import numpy as np
+
+    tim_path = Path(tim_path)
+    toas = get_TOAs(str(tim_path), include_pn=True)
+    n_toas = len(toas)
+    if n_toas == 0:
+        return "none", 0, 0
+
+    if "pulse_number" not in toas.table.colnames:
+        return "none", 0, n_toas
+
+    pn = np.asarray(toas.table["pulse_number"])
+    has_pn = np.isfinite(pn)
+    n_with = int(np.sum(has_pn))
+    n_without = n_toas - n_with
+    if n_with == 0:
+        return "none", 0, n_without
+    if n_without == 0:
+        return "complete", n_with, 0
+    return "mixed", n_with, n_without
+
+
+def sanitize_tempo2_tim_noise_directives(tim_text: str) -> str:
+    """Remove Tempo2 white-noise directive lines (T2E*, TNE*) from .tim text."""
+    kept: List[str] = []
+    for line in tim_text.splitlines(keepends=True):
+        stripped = line.strip()
+        if not stripped:
+            kept.append(line)
+            continue
+        if stripped.startswith("#") or stripped.upper().startswith("C "):
+            kept.append(line)
+            continue
+        first_token = stripped.split()[0]
+        if first_token.startswith("T2E") or first_token.startswith("TNE"):
+            continue
+        kept.append(line)
+    return "".join(kept)
+
+
+def _should_derive_pulse_numbers(
+    mode: PulseNumberMode,
+    status: TimPulseNumberStatus,
+    tim_path: Path,
+    n_with: int,
+    n_without: int,
+) -> bool:
+    """Return True when pulse numbers must be re-derived for this mode/status."""
+    if mode == "no":
+        return False
+    if mode == "overwrite":
+        return True
+    if status == "complete":
+        return False
+    if status == "mixed":
+        loguru_logger.warning(
+            "Mixed -pn flags in {}: {} TOAs with -pn, {} without; re-deriving pulse numbers",
+            tim_path,
+            n_with,
+            n_without,
+        )
+        return True
+    # none
+    if mode == "reuse":
+        loguru_logger.warning(
+            "No complete -pn in {}; re-deriving pulse numbers (reuse mode)",
+            tim_path,
+        )
+    return True
+
+
+def ensure_pint_track_minus_2(model: TimingModel) -> None:
+    """Set PINT TRACK to -2 for pulse-number tracking."""
+    if "TRACK" in model.params:
+        model.TRACK.value = "-2"
+    else:
+        loguru_logger.warning(
+            "TRACK parameter not in PINT timing model; "
+            "pulse-number tracking may be ineffective"
+        )
+
+
+def ensure_pulse_numbers(
+    toas: TOAs, model: TimingModel, *, force_recompute: bool = False
+) -> TOAs:
     """Ensure TOAs has a complete pulse_number column.
 
     If a -pn flag was present in the .tim, PINT already parsed it into
@@ -521,6 +633,9 @@ def ensure_pulse_numbers(toas: TOAs, model: TimingModel) -> TOAs:
 
     if "delta_pulse_number" not in toas.table.colnames:
         toas.table["delta_pulse_number"] = np.zeros(len(toas))
+    if force_recompute:
+        toas.compute_pulse_numbers(model)
+        return toas
     if ("pulse_number" not in toas.table.colnames) or (
         toas.table["pulse_number"] != toas.table["pulse_number"]
     ).any():  # NaN check
@@ -537,13 +652,16 @@ def write_pn_tim(toas: TOAs, out_path: Path) -> Path:
 
 @contextmanager
 def temporary_pn_tim_from_par_tim_pint(
-    parfile_text: str, tim_path: Path
+    parfile_text: str,
+    tim_path: Path,
+    *,
+    force_recompute: bool = False,
 ) -> Iterator[str]:
     """Yield a temporary pn-tagged .tim derived via PINT; file is deleted on exit."""
     tim_path = Path(tim_path)
     model = create_pint_model(parfile_text)
     toas = get_TOAs(str(tim_path), model=model, include_pn=True)
-    ensure_pulse_numbers(toas, model)
+    ensure_pulse_numbers(toas, model, force_recompute=force_recompute)
     with tempfile.TemporaryDirectory(prefix="withpn_pint_") as td:
         out_path = Path(td) / "withpn.tim"
         write_pn_tim(toas, out_path)
@@ -638,8 +756,46 @@ def temporary_pn_tim_from_par_tim_tempo2(
         src = td_path / "withpn.tim"
         if not src.exists():
             raise RuntimeError("tempo2 plugin did not produce withpn.tim")
+        sanitized = sanitize_tempo2_tim_noise_directives(
+            src.read_text(encoding="utf-8")
+        )
+        src.write_text(sanitized, encoding="utf-8")
         yield str(src)
     # temp dir auto-removed
+
+
+@contextmanager
+def resolved_tim_for_pulse_numbers(
+    mode: PulseNumberMode,
+    parfile_text: str,
+    tim_path: Path,
+    *,
+    derive_backend: Literal["pint", "tempo2"],
+) -> Iterator[str]:
+    """Yield the .tim path to load for the given pulse-number mode."""
+    tim_path = Path(tim_path)
+    if mode == "no":
+        yield str(tim_path)
+        return
+
+    status, n_with, n_without = classify_tim_pulse_numbers(tim_path)
+    derive = _should_derive_pulse_numbers(mode, status, tim_path, n_with, n_without)
+
+    if not derive:
+        yield str(tim_path)
+        return
+
+    force_recompute = mode == "overwrite"
+    if derive_backend == "pint":
+        with temporary_pn_tim_from_par_tim_pint(
+            parfile_text,
+            tim_path,
+            force_recompute=force_recompute,
+        ) as pn_tim:
+            yield pn_tim
+    else:
+        with temporary_pn_tim_from_par_tim_tempo2(parfile_text, tim_path) as pn_tim:
+            yield pn_tim
 
 
 def _write_pn_tim_libstempo(psr, out_path: Path) -> None:
@@ -719,12 +875,41 @@ def temporary_pn_tim_from_par_tim_libstempo(
         yield str(out_tim)
 
 
+def par_text_with_track_minus_2(par_text: str) -> str:
+    """Return par text with TRACK set to -2 using line-based editing.
+
+    Avoids PINT re-serialization, which can fail on Tempo2 fit flags (``N``/``Y``).
+    """
+    out_lines: List[str] = []
+    replaced = False
+    for line in par_text.splitlines():
+        stripped = line.strip()
+        if (
+            not stripped
+            or stripped.startswith("#")
+            or stripped.upper().startswith("C ")
+        ):
+            out_lines.append(line)
+            continue
+        first_token = stripped.split()[0]
+        if first_token.upper() == "TRACK":
+            prefix = line[: len(line) - len(line.lstrip())]
+            out_lines.append(f"{prefix}TRACK -2")
+            replaced = True
+        else:
+            out_lines.append(line)
+    if not replaced:
+        out_lines.append("TRACK -2")
+    result = "\n".join(out_lines)
+    if par_text.endswith("\n"):
+        result += "\n"
+    return result
+
+
 @contextmanager
 def temporary_par_with_track_minus_2(par_text: str) -> Iterator[str]:
     """Yield a temporary tempo2-formatted par file with TRACK -2; deleted on exit."""
-    par_dict = parse_parfile(StringIO(par_text))
-    par_dict["TRACK"] = ["-2"]
-    par_out = dict_to_parfile_string(par_dict, format="tempo2")
+    par_out = par_text_with_track_minus_2(par_text)
     with tempfile.NamedTemporaryFile(mode="w", suffix=".par", delete=False) as tf:
         tf.write(par_out)
         tf.flush()

--- a/src/metapulsar/pint_helpers.py
+++ b/src/metapulsar/pint_helpers.py
@@ -4,7 +4,7 @@ This module provides pure functions that encapsulate PINT-specific logic
 for parameter discovery, alias resolution, and model validation.
 """
 
-from typing import Dict, List, Tuple, Any, Iterator, Literal
+from typing import Dict, List, Tuple, Any, Iterator, Literal, Optional, TYPE_CHECKING
 from functools import lru_cache
 from pint.models import TimingModel
 from pint.models.timing_model import AllComponents
@@ -15,6 +15,9 @@ import tempfile
 import subprocess
 from io import StringIO
 import numpy as np
+
+if TYPE_CHECKING:
+    from .tim_file_analyzer import TimMetadata
 
 
 class PINTDiscoveryError(Exception):
@@ -118,6 +121,65 @@ def get_aliases_for_parameter(canonical_param: str) -> List[str]:
     except Exception:
         # If anything fails, just return the canonical name
         return [canonical_param]
+
+
+def _parfile_alias_value_present(parfile_dict: Dict[str, Any], alias: str) -> bool:
+    """Return True if alias is present in a parfile dict with a non-empty value."""
+    if alias not in parfile_dict:
+        return False
+    value = parfile_dict[alias]
+    if value is None:
+        return False
+    if isinstance(value, list):
+        if not value:
+            return False
+        return bool(str(value[0]).strip())
+    return bool(str(value).strip())
+
+
+def has_parameter_alias(parfile_dict: Dict[str, Any], canonical_param: str) -> bool:
+    """Return True if any PINT alias for canonical_param is present and non-empty."""
+    return any(
+        _parfile_alias_value_present(parfile_dict, alias)
+        for alias in get_aliases_for_parameter(canonical_param)
+    )
+
+
+def has_equatorial_astrometry(parfile_dict: Dict[str, Any]) -> bool:
+    """Return True if equatorial astrometry parameters are present (via PINT aliases)."""
+    return has_parameter_alias(parfile_dict, "RAJ") and has_parameter_alias(
+        parfile_dict, "DECJ"
+    )
+
+
+def has_ecliptic_astrometry(parfile_dict: Dict[str, Any]) -> bool:
+    """Return True if ecliptic astrometry parameters are present (via PINT aliases)."""
+    return has_parameter_alias(parfile_dict, "ELONG") and has_parameter_alias(
+        parfile_dict, "ELAT"
+    )
+
+
+def detect_astrometry_style(parfile_dict: Dict[str, Any]) -> str:
+    """Detect whether a parfile uses equatorial or ecliptic astrometry.
+
+    Uses PINT's alias map rather than hard-coded parameter names.
+    """
+    has_equatorial = has_equatorial_astrometry(parfile_dict)
+    has_ecliptic = has_ecliptic_astrometry(parfile_dict)
+
+    if has_equatorial and has_ecliptic:
+        raise ValueError(
+            "Mixed astrometry detected (equatorial and ecliptic parameters present). "
+            "Refuse to make ambiguous coordinate representation consistent."
+        )
+    if has_ecliptic:
+        return "ecliptic"
+    if has_equatorial:
+        return "equatorial"
+    raise ValueError(
+        "Could not detect astrometry style. Expected either RAJ/DECJ or "
+        "LAMBDA/BETA (or ELONG/ELAT)."
+    )
 
 
 def clear_all_components_cache():
@@ -532,34 +594,6 @@ def pulse_number_tracking_enabled(mode: PulseNumberMode) -> bool:
     return mode in ("yes", "reuse", "overwrite")
 
 
-def classify_tim_pulse_numbers(tim_path: Path) -> Tuple[TimPulseNumberStatus, int, int]:
-    """Classify -pn coverage on TOA lines in a .tim file.
-
-    Returns:
-        (status, n_with_pn, n_without_pn) where status is complete, mixed, or none.
-    """
-    import numpy as np
-
-    tim_path = Path(tim_path)
-    toas = get_TOAs(str(tim_path), include_pn=True)
-    n_toas = len(toas)
-    if n_toas == 0:
-        return "none", 0, 0
-
-    if "pulse_number" not in toas.table.colnames:
-        return "none", 0, n_toas
-
-    pn = np.asarray(toas.table["pulse_number"])
-    has_pn = np.isfinite(pn)
-    n_with = int(np.sum(has_pn))
-    n_without = n_toas - n_with
-    if n_with == 0:
-        return "none", 0, n_without
-    if n_without == 0:
-        return "complete", n_with, 0
-    return "mixed", n_with, n_without
-
-
 def sanitize_tempo2_tim_noise_directives(tim_text: str) -> str:
     """Remove Tempo2 white-noise directive lines (T2E*, TNE*) from .tim text."""
     kept: List[str] = []
@@ -771,14 +805,22 @@ def resolved_tim_for_pulse_numbers(
     tim_path: Path,
     *,
     derive_backend: Literal["pint", "tempo2"],
+    tim_metadata: Optional["TimMetadata"] = None,
 ) -> Iterator[str]:
     """Yield the .tim path to load for the given pulse-number mode."""
+    from .tim_file_analyzer import TimFileAnalyzer
+
     tim_path = Path(tim_path)
     if mode == "no":
         yield str(tim_path)
         return
 
-    status, n_with, n_without = classify_tim_pulse_numbers(tim_path)
+    if tim_metadata is None:
+        tim_metadata = TimFileAnalyzer().get_tim_metadata(tim_path)
+
+    status = tim_metadata.pn_status
+    n_with = tim_metadata.pn_with_count
+    n_without = tim_metadata.pn_without_count
     derive = _should_derive_pulse_numbers(mode, status, tim_path, n_with, n_without)
 
     if not derive:

--- a/src/metapulsar/sandbox_tempo2.py
+++ b/src/metapulsar/sandbox_tempo2.py
@@ -1436,7 +1436,7 @@ class tempopulsar:
 
             logger.info(f"Proactively counting TOAs in {timfile_path}")
             analyzer = TimFileAnalyzer()
-            toa_count = analyzer.count_toas(timfile_path)
+            toa_count = analyzer.get_tim_metadata(timfile_path).toa_count
 
             if toa_count > self._policy.nobs_threshold:
                 maxobs_with_margin = int(toa_count * self._policy.nobs_safety_margin)

--- a/src/metapulsar/tim_file_analyzer.py
+++ b/src/metapulsar/tim_file_analyzer.py
@@ -1,225 +1,320 @@
-"""TimFileAnalyzer - Fast TIM file analyzer for timespan calculation.
+"""TimFileAnalyzer - lightweight TIM file metadata parser.
 
-This module provides a lightweight class to quickly extract TOA MJD values
-from TIM files using PINT's parsing logic without creating full TOA objects,
-which is much faster for timespan calculations.
+Single source of truth for file-level .tim metadata: TOA count, MJD range,
+timespan, and pulse-number (-pn) coverage. No PINT dependency.
 """
 
+from __future__ import annotations
+
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Set, Dict, Tuple
+from typing import Dict, List, Literal, Optional, Set, Tuple
 from loguru import logger
 
-# Import PINT's parsing functions directly
-from pint.toa import _parse_TOA_line
+TimPulseNumberStatus = Literal["complete", "mixed", "none"]
+
+# Known directive prefixes (uppercase first token)
+_DIRECTIVE_PREFIXES = frozenset(
+    {
+        "MODE",
+        "JUMP",
+        "EFAC",
+        "EQUAD",
+        "TIME",
+        "PHASE",
+        "SKIP",
+        "NOSKIP",
+        "FORMAT",
+        "INCLUDE",
+    }
+)
+
+
+@dataclass(frozen=True)
+class TimMetadata:
+    """Structured metadata extracted from a .tim file (including INCLUDEs)."""
+
+    toa_count: int
+    mjd_min: Optional[float]
+    mjd_max: Optional[float]
+    timespan_days: float
+    pn_with_count: int
+    pn_without_count: int
+    pn_status: TimPulseNumberStatus
+    lines_seen: int = 0
+    lines_skipped: int = 0
+    parse_warnings: Tuple[str, ...] = ()
+
+
+class _ParseAccumulator:
+    """Mutable accumulator for a single metadata parse."""
+
+    def __init__(self) -> None:
+        self.toa_count = 0
+        self.mjd_min: Optional[float] = None
+        self.mjd_max: Optional[float] = None
+        self.pn_with_count = 0
+        self.pn_without_count = 0
+        self.lines_seen = 0
+        self.lines_skipped = 0
+        self.warnings: List[str] = []
+
+    def record_toa(self, mjd: float, has_pn: bool) -> None:
+        self.toa_count += 1
+        if self.mjd_min is None or mjd < self.mjd_min:
+            self.mjd_min = mjd
+        if self.mjd_max is None or mjd > self.mjd_max:
+            self.mjd_max = mjd
+        if has_pn:
+            self.pn_with_count += 1
+        else:
+            self.pn_without_count += 1
+
+    def skip_line(self) -> None:
+        self.lines_skipped += 1
+
+    def add_warning(self, message: str) -> None:
+        self.warnings.append(message)
+
+    def to_metadata(self) -> TimMetadata:
+        if self.toa_count == 0:
+            timespan = 0.0
+            pn_status: TimPulseNumberStatus = "none"
+        else:
+            timespan = float(self.mjd_max - self.mjd_min)  # type: ignore[operator]
+            if self.pn_with_count == 0:
+                pn_status = "none"
+            elif self.pn_without_count == 0:
+                pn_status = "complete"
+            else:
+                pn_status = "mixed"
+        return TimMetadata(
+            toa_count=self.toa_count,
+            mjd_min=self.mjd_min,
+            mjd_max=self.mjd_max,
+            timespan_days=timespan,
+            pn_with_count=self.pn_with_count,
+            pn_without_count=self.pn_without_count,
+            pn_status=pn_status,
+            lines_seen=self.lines_seen,
+            lines_skipped=self.lines_skipped,
+            parse_warnings=tuple(self.warnings),
+        )
 
 
 class TimFileAnalyzer:
-    """Fast TIM file analyzer for timespan calculation.
+    """Lightweight TIM file analyzer for unified metadata extraction.
 
-    This class efficiently extracts TOA MJD values from TIM files using PINT's
-    parsing logic without creating full TOA objects, providing both performance
-    and robustness for timespan calculations.
-
-    The analyzer caches results per file to avoid duplicate parsing when both
-    timespan and TOA count are needed for the same file.
+    Parses .tim files recursively (including INCLUDE) with explicit FORMAT
+    state tracking. Results are cached by resolved path and mtime.
     """
 
-    def __init__(self):
-        """Initialize the TIM file analyzer."""
+    def __init__(self) -> None:
         self.logger = logger
-        self._processed_files: Set[Path] = set()
-        # Cache for storing timespan and TOA counts per file (not MJD values to save memory)
-        self._file_cache: Dict[Path, Tuple[float, int]] = {}
+        self._file_cache: Dict[Path, Tuple[float, TimMetadata]] = {}
 
-    def _get_timespan_and_count(self, tim_file_path: Path) -> Tuple[float, int]:
-        """Get timespan and TOA count from TIM file, using cache if available.
+    def get_tim_metadata(self, tim_file_path: Path) -> TimMetadata:
+        """Return unified metadata for a .tim file (cached by path + mtime)."""
+        resolved = Path(tim_file_path).resolve()
+        mtime = self._safe_mtime(resolved)
 
-        Args:
-            tim_file_path: Path to the TIM file
-
-        Returns:
-            Tuple of (timespan_in_days, toa_count)
-        """
-        # Check cache first
-        if tim_file_path in self._file_cache:
-            self.logger.debug(f"Using cached data for {tim_file_path}")
-            return self._file_cache[tim_file_path]
+        cached = self._file_cache.get(resolved)
+        if cached is not None and cached[0] == mtime:
+            self.logger.debug(f"Using cached metadata for {resolved}")
+            return cached[1]
 
         try:
-            self._processed_files.clear()
-            mjd_values = self._extract_mjd_values_recursive(tim_file_path)
-            toa_count = len(mjd_values)
-
-            if toa_count == 0:
-                timespan = 0.0
-            else:
-                # Calculate timespan as max - min (no need to sort)
-                timespan = float(max(mjd_values) - min(mjd_values))
-
-            # Cache only the results we need (timespan and count)
-            self._file_cache[tim_file_path] = (timespan, toa_count)
-
-            if toa_count > 0:
+            acc = _ParseAccumulator()
+            active: Set[Path] = set()
+            self._parse_file(resolved, format_tokenized=False, acc=acc, active=active)
+            meta = acc.to_metadata()
+            self._file_cache[resolved] = (mtime, meta)
+            if meta.toa_count > 0:
                 self.logger.debug(
-                    f"Cached data for {tim_file_path}: {timespan:.1f} days, {toa_count} TOAs"
+                    f"Cached metadata for {resolved}: "
+                    f"{meta.timespan_days:.1f} days, {meta.toa_count} TOAs, "
+                    f"pn={meta.pn_status}"
                 )
             else:
-                self.logger.debug(f"Cached data for {tim_file_path}: No TOAs found")
-            return timespan, toa_count
-
+                self.logger.debug(f"Cached metadata for {resolved}: no TOAs found")
+            return meta
         except Exception as e:
-            self.logger.warning(f"Parsing failed for {tim_file_path}: {e}")
-            self.logger.debug(
-                "File may contain non-standard TIM format or malformed data"
+            self.logger.warning(f"Parsing failed for {resolved}: {e}")
+            empty = TimMetadata(
+                toa_count=0,
+                mjd_min=None,
+                mjd_max=None,
+                timespan_days=0.0,
+                pn_with_count=0,
+                pn_without_count=0,
+                pn_status="none",
+                parse_warnings=(f"parse failed: {e}",),
             )
-            # Cache empty result to avoid repeated failures
-            empty_result = (0.0, 0)
-            self._file_cache[tim_file_path] = empty_result
-            return empty_result
-
-    def calculate_timespan(self, tim_file_path: Path) -> float:
-        """Calculate timespan from TIM file using PINT's parsing logic.
-
-        Args:
-            tim_file_path: Path to the TIM file
-
-        Returns:
-            Timespan in days (max(mjd) - min(mjd))
-        """
-        timespan, toa_count = self._get_timespan_and_count(tim_file_path)
-
-        if toa_count == 0:
-            self.logger.warning(f"No TOAs found in {tim_file_path}")
-            return 0.0
-
-        self.logger.debug(
-            f"Timespan for {tim_file_path}: {timespan:.1f} days ({toa_count} TOAs)"
-        )
-        return timespan
-
-    def count_toas(self, tim_file_path: Path) -> int:
-        """Count the number of TOAs in a TIM file.
-
-        Args:
-            tim_file_path: Path to the TIM file
-
-        Returns:
-            Number of TOAs found in the file
-        """
-        _, toa_count = self._get_timespan_and_count(tim_file_path)
-
-        self.logger.debug(f"TOA count for {tim_file_path}: {toa_count} TOAs")
-        return toa_count
+            self._file_cache[resolved] = (mtime, empty)
+            return empty
 
     def clear_cache(self) -> None:
-        """Clear the file cache."""
+        """Clear the metadata cache."""
         self._file_cache.clear()
-        self.logger.debug("File cache cleared")
+        self.logger.debug("Metadata cache cleared")
 
-    def get_timespan_and_count(self, tim_file_path: Path) -> Tuple[float, int]:
-        """Get both timespan and TOA count efficiently using cached data.
-
-        Args:
-            tim_file_path: Path to the TIM file
-
-        Returns:
-            Tuple of (timespan_in_days, toa_count)
-        """
-        timespan, toa_count = self._get_timespan_and_count(tim_file_path)
-
-        if toa_count == 0:
-            self.logger.warning(f"No TOAs found in {tim_file_path}")
-            return 0.0, 0
-
-        self.logger.debug(
-            f"Timespan and count for {tim_file_path}: {timespan:.1f} days, {toa_count} TOAs"
-        )
-        return timespan, toa_count
-
-    def _extract_mjd_values_recursive(self, tim_file_path: Path) -> List[float]:
-        """Recursively extract MJD values from TIM file and included files.
-
-        Args:
-            tim_file_path: Path to the TIM file
-
-        Returns:
-            List of MJD values from all TOA lines
-        """
-        mjd_values = []
-
-        # Avoid infinite recursion
-        if tim_file_path in self._processed_files:
-            self.logger.warning(f"Circular INCLUDE detected: {tim_file_path}")
-            return mjd_values
-
-        self._processed_files.add(tim_file_path)
-
+    @staticmethod
+    def _safe_mtime(path: Path) -> float:
         try:
-            with open(tim_file_path, "r") as f:
-                for line_num, line in enumerate(f, 1):
-                    line = line.strip()
+            return path.stat().st_mtime
+        except OSError:
+            return -1.0
 
-                    # Skip empty lines
-                    if not line:
-                        continue
-
-                    # Use PINT's parsing for both TOA lines and commands
-                    try:
-                        mjd_tuple, d = _parse_TOA_line(line)
-                    except Exception as e:
-                        # PINT may fail on malformed lines - skip them gracefully
-                        self.logger.debug(
-                            f"Skipping malformed line in {tim_file_path}: {line.strip()} - {e}"
-                        )
-                        continue
-
-                    # Handle commands (especially INCLUDE)
-                    if d["format"] == "Command":
-                        self._handle_command(d, tim_file_path, mjd_values)
-                        continue
-
-                    # Skip non-TOA lines
-                    if d["format"] in ("Comment", "Blank", "Unknown"):
-                        continue
-
-                    # Extract MJD from TOA line
-                    if mjd_tuple is not None:
-                        # Convert PINT's (int, float) tuple to float MJD
-                        mjd_value = float(mjd_tuple[0]) + float(mjd_tuple[1])
-                        mjd_values.append(mjd_value)
-
-        except Exception as e:
-            self.logger.error(f"Error reading TIM file {tim_file_path}: {e}")
-
-        return mjd_values
-
-    def _handle_command(
-        self, d: dict, current_file: Path, mjd_values: List[float]
+    def _parse_file(
+        self,
+        tim_file_path: Path,
+        *,
+        format_tokenized: bool,
+        acc: _ParseAccumulator,
+        active: Set[Path],
     ) -> None:
-        """Handle TIM file commands using PINT's parsed command data.
-
-        Args:
-            d: Parsed command dictionary from PINT
-            current_file: Current TIM file being processed
-            mjd_values: List to extend with MJD values from included files
-        """
-        if d["format"] != "Command":
+        if tim_file_path in active:
+            msg = f"Circular INCLUDE detected: {tim_file_path}"
+            self.logger.warning(msg)
+            acc.add_warning(msg)
             return
 
-        cmd = d["Command"][0].upper()
+        active.add(tim_file_path)
+        try:
+            with open(tim_file_path, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    acc.lines_seen += 1
+                    format_tokenized = self._process_line(
+                        stripped,
+                        tim_file_path,
+                        format_tokenized=format_tokenized,
+                        acc=acc,
+                        active=active,
+                    )
+        except OSError as e:
+            msg = f"Error reading TIM file {tim_file_path}: {e}"
+            self.logger.error(msg)
+            acc.add_warning(msg)
+        finally:
+            active.discard(tim_file_path)
 
-        if cmd == "INCLUDE":
-            if len(d["Command"]) < 2:
-                self.logger.warning(f"INCLUDE command without filename: {d['Command']}")
-                return
+    def _process_line(
+        self,
+        line: str,
+        current_file: Path,
+        *,
+        format_tokenized: bool,
+        acc: _ParseAccumulator,
+        active: Set[Path],
+    ) -> bool:
+        """Process one line; return updated format_tokenized state."""
+        if line.startswith("#"):
+            return format_tokenized
+        if line.upper().startswith("C "):
+            return format_tokenized
 
-            include_file = d["Command"][1]
-            include_path = current_file.parent / include_file
+        tokens = line.split()
+        if not tokens:
+            return format_tokenized
 
+        first = tokens[0].upper()
+
+        if first == "FORMAT":
+            if len(tokens) >= 2 and tokens[1] == "1":
+                return True
+            return False
+
+        if first == "INCLUDE":
+            if len(tokens) < 2:
+                msg = f"INCLUDE command without filename in {current_file}"
+                self.logger.warning(msg)
+                acc.add_warning(msg)
+                acc.skip_line()
+                return format_tokenized
+            include_path = (current_file.parent / tokens[1]).resolve()
             if include_path.exists():
                 self.logger.debug(f"Processing included TOA file {include_path}")
-                included_mjds = self._extract_mjd_values_recursive(include_path)
-                mjd_values.extend(included_mjds)
+                self._parse_file(
+                    include_path,
+                    format_tokenized=format_tokenized,
+                    acc=acc,
+                    active=active,
+                )
             else:
-                self.logger.warning(f"INCLUDE file not found: {include_path}")
-        # Other commands don't affect timespan calculation
+                msg = f"INCLUDE file not found: {include_path}"
+                self.logger.warning(msg)
+                acc.add_warning(msg)
+            return format_tokenized
+
+        if self._is_directive(tokens):
+            return format_tokenized
+
+        if format_tokenized:
+            parsed = self._parse_tokenized_toa(tokens)
+            if parsed is None:
+                acc.skip_line()
+                return format_tokenized
+            mjd, has_pn = parsed
+            acc.record_toa(mjd, has_pn)
+            return format_tokenized
+
+        parsed = self._parse_legacy_toa(line, tokens)
+        if parsed is None:
+            acc.skip_line()
+            return format_tokenized
+        mjd, has_pn = parsed
+        acc.record_toa(mjd, has_pn)
+        return format_tokenized
+
+    @staticmethod
+    def _is_directive(tokens: List[str]) -> bool:
+        first = tokens[0].upper()
+        if first in _DIRECTIVE_PREFIXES:
+            return True
+        if first.startswith("T2E") or first.startswith("TNE"):
+            return True
+        return False
+
+    @staticmethod
+    def _parse_tokenized_toa(tokens: List[str]) -> Optional[Tuple[float, bool]]:
+        """Parse FORMAT 1 tokenized TOA: name freq mjd err site [flags...]."""
+        if len(tokens) < 5:
+            return None
+        try:
+            mjd = float(tokens[2])
+        except ValueError:
+            return None
+
+        has_pn = False
+        i = 5
+        while i + 1 < len(tokens):
+            flag_key = tokens[i].lstrip("-").lower()
+            if flag_key == "pn":
+                has_pn = True
+            i += 2
+        return mjd, has_pn
+
+    @staticmethod
+    def _parse_legacy_toa(line: str, tokens: List[str]) -> Optional[Tuple[float, bool]]:
+        """Minimal legacy TOA support (Princeton / whitespace tokenized)."""
+        # Princeton: first char alnum/@, tokens include freq and mjd
+        if tokens[0][0].isalnum() or tokens[0][0] == "@":
+            if len(tokens) >= 3:
+                try:
+                    return float(tokens[2]), False
+                except ValueError:
+                    pass
+
+        # Parkes-like: decimal at column 42 (0-based index 41)
+        if len(line) > 42 and line[41] == ".":
+            mjd_str = line[10:27].strip()
+            if mjd_str:
+                try:
+                    return float(mjd_str), False
+                except ValueError:
+                    pass
+
+        return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import pytest
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,36 @@
+"""Shared helpers for MetaPulsar tests."""
+
+from typing import Literal, Optional
+
+from metapulsar.tim_file_analyzer import TimMetadata
+
+TimPulseNumberStatus = Literal["complete", "mixed", "none"]
+
+
+def make_tim_metadata(
+    *,
+    timespan_days: float = 0.0,
+    toa_count: int = 0,
+    pn_status: TimPulseNumberStatus = "none",
+    pn_with_count: Optional[int] = None,
+    pn_without_count: Optional[int] = None,
+) -> TimMetadata:
+    """Build TimMetadata for tests without parsing a .tim file."""
+    if pn_with_count is None:
+        if pn_status == "complete":
+            pn_with_count = toa_count
+        elif pn_status == "mixed":
+            pn_with_count = max(0, toa_count // 2)
+        else:
+            pn_with_count = 0
+    if pn_without_count is None:
+        pn_without_count = toa_count - pn_with_count
+    return TimMetadata(
+        toa_count=toa_count,
+        mjd_min=None,
+        mjd_max=None,
+        timespan_days=timespan_days,
+        pn_with_count=pn_with_count,
+        pn_without_count=pn_without_count,
+        pn_status=pn_status,
+    )

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -60,7 +60,7 @@ DM 13.299 1 0.001
                         ]
                     }
                     MetaPulsarFactory().create_metapulsar(
-                        file_data, use_pulse_numbers=False
+                        file_data, use_pulse_numbers="no"
                     )
 
     def test_malformed_tim_file(self, available_data_sets):
@@ -101,7 +101,7 @@ C 12345.67890 0.0001
                         ]
                     }
                     MetaPulsarFactory().create_metapulsar(
-                        file_data, use_pulse_numbers=False
+                        file_data, use_pulse_numbers="no"
                     )
 
     def test_invalid_data_release_config(self):
@@ -181,9 +181,7 @@ PEPOCH 55000
                         }
                     ]
                 }
-                MetaPulsarFactory().create_metapulsar(
-                    file_data, use_pulse_numbers=False
-                )
+                MetaPulsarFactory().create_metapulsar(file_data, use_pulse_numbers="no")
 
     @pytest.mark.slow
     @pytest.mark.requires_libstempo
@@ -235,9 +233,7 @@ PEPOCH 55000
                         }
                     ]
                 }
-                MetaPulsarFactory().create_metapulsar(
-                    file_data, use_pulse_numbers=False
-                )
+                MetaPulsarFactory().create_metapulsar(file_data, use_pulse_numbers="no")
 
     def test_memory_limit_handling(self, available_data_sets):
         """Test handling of memory limits with large datasets."""

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -7,6 +7,7 @@ from metapulsar import MetaPulsarFactory, FileDiscoveryService
 from metapulsar.file_discovery_service import PTA_DATA_RELEASES
 from metapulsar.pint_helpers import PINTDiscoveryError
 from metapulsar.sandbox_tempo2 import Tempo2Error
+from tests.helpers import make_tim_metadata
 
 
 @pytest.mark.integration
@@ -55,7 +56,7 @@ DM 13.299 1 0.001
                                 "tim": Path(temp_dir) / "J0030+0451.tim",
                                 "par_content": malformed_parfile_content,
                                 "timing_package": "tempo2",
-                                "timespan_days": 1000.0,
+                                "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                             }
                         ]
                     }
@@ -96,7 +97,7 @@ C 12345.67890 0.0001
                                 "tim": temp_tim,
                                 "par_content": "PSR J0030+0451\nRAJ 00:30:27.4\nDECJ 04:51:39.7\n",
                                 "timing_package": "tempo2",
-                                "timespan_days": 1000.0,
+                                "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                             }
                         ]
                     }
@@ -119,7 +120,7 @@ C 12345.67890 0.0001
                     "tim": Path("/nonexistent/J0030+0451.tim"),
                     "par_content": "PSR J0030+0451\nRAJ 00:30:27.4\nDECJ 04:51:39.7\nF0 327.405\nF1 -1.2e-15\n",
                     "timing_package": "tempo2",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                 }
             ]
         }
@@ -177,7 +178,7 @@ PEPOCH 55000
                             "tim": Path(temp_dir) / "J0030+0451.tim",
                             "par_content": minimal_parfile_content,  # Minimal valid content
                             "timing_package": "tempo2",
-                            "timespan_days": 1000.0,
+                            "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                         }
                     ]
                 }
@@ -229,7 +230,7 @@ PEPOCH 55000
                             "tim": Path(temp_dir) / "J0030+0451.tim",
                             "par_content": valid_parfile_content,  # Valid content for coordinate discovery
                             "timing_package": "tempo2",
-                            "timespan_days": 1000.0,
+                            "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                         }
                     ]
                 }

--- a/tests/integration/test_legacy_comparison.py
+++ b/tests/integration/test_legacy_comparison.py
@@ -129,7 +129,7 @@ class TestLegacyComparison:
 
             new_mp = new_module["MetaPulsarFactory"]().create_metapulsar(
                 file_data=filtered_file_data,
-                use_pulse_numbers=False,
+                use_pulse_numbers="no",
             )
 
             # Compare basic properties
@@ -430,7 +430,7 @@ class TestLegacyComparison:
 
             new_mp = new_module["MetaPulsarFactory"]().create_metapulsar(
                 file_data=filtered_file_data,
-                use_pulse_numbers=False,
+                use_pulse_numbers="no",
             )
 
             # Get design matrices
@@ -591,7 +591,7 @@ class TestLegacyComparison:
 
             new_mp = new_module["MetaPulsarFactory"]().create_metapulsar(
                 file_data=filtered_file_data,
-                use_pulse_numbers=False,
+                use_pulse_numbers="no",
             )
 
             # Get flags
@@ -701,7 +701,7 @@ class TestLegacyComparison:
 
             new_mp = new_module["MetaPulsarFactory"]().create_metapulsar(
                 file_data=filtered_file_data,
-                use_pulse_numbers=False,
+                use_pulse_numbers="no",
             )
 
             # Get intermediate par files (if available)
@@ -801,7 +801,7 @@ class TestLegacyComparison:
 
             new_mp = new_module["MetaPulsarFactory"]().create_metapulsar(
                 file_data=filtered_file_data,
-                use_pulse_numbers=False,
+                use_pulse_numbers="no",
             )
 
             # Get fitpars from both implementations
@@ -833,7 +833,12 @@ class TestLegacyComparison:
     def test_pulse_number_mode_residual_equivalence(
         self, new_module, available_data_sets
     ):
-        """Pulse-number and non-pulse-number paths should match to machine precision."""
+        """Pulse-number and non-pulse-number paths should match to machine precision.
+
+        Unlike ``tests/test_pulse_tracking.py`` (synthetic PTAs where consistent
+        merging breaks DM/DMX coherence), this IPTA case stays coherent after merge,
+        so ``yes`` and ``no`` should yield the same residuals.
+        """
         if not available_data_sets:
             pytest.skip("No data available for testing")
 
@@ -856,11 +861,11 @@ class TestLegacyComparison:
         factory = new_module["MetaPulsarFactory"]()
         mp_without_pn = factory.create_metapulsar(
             file_data=filtered_file_data,
-            use_pulse_numbers=False,
+            use_pulse_numbers="no",
         )
         mp_with_pn = factory.create_metapulsar(
             file_data=filtered_file_data,
-            use_pulse_numbers=True,
+            use_pulse_numbers="yes",
         )
 
         assert len(mp_without_pn._residuals) == len(mp_with_pn._residuals)

--- a/tests/test_coordinate_based_discovery.py
+++ b/tests/test_coordinate_based_discovery.py
@@ -19,6 +19,7 @@ from metapulsar.position_helpers import (
     discover_pulsars_by_coordinates_optimized,
 )
 from metapulsar.metapulsar import MetaPulsar
+from tests.helpers import make_tim_metadata
 
 
 # === FIXTURES ===
@@ -211,7 +212,7 @@ class TestCoordinateBasedDiscovery:
                         "tim": mock_file_system / "data1" / "J1857+0943.tim",
                         "par_content": "PSR J1857+0943\nRAJ 18:57:36.4\nDECJ 09:43:17.1\n",
                         "timing_package": "pint",
-                        "timespan_days": 1000.0,
+                        "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     }
                 ],
                 "test_data_release2": [
@@ -220,7 +221,7 @@ class TestCoordinateBasedDiscovery:
                         "tim": mock_file_system / "data2" / "J1857+0943.tim",
                         "par_content": "PSR J1857+0943\nRAJ 18:57:36.4\nDECJ 09:43:17.1\n",
                         "timing_package": "pint",
-                        "timespan_days": 1000.0,
+                        "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     }
                 ],
             }
@@ -317,7 +318,7 @@ class TestEdgeCases:
                         "tim": mock_file_system / "data1" / "malformed.tim",
                         "par_content": "This is not a valid parfile",
                         "timing_package": "pint",
-                        "timespan_days": 1000.0,
+                        "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     }
                 ]
             }

--- a/tests/test_file_discovery_service.py
+++ b/tests/test_file_discovery_service.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 from metapulsar.file_discovery_service import FileDiscoveryService, PTA_DATA_RELEASES
 from metapulsar import discover_files
+from tests.helpers import make_tim_metadata
 
 
 class TestFileDiscoveryService:
@@ -79,7 +80,7 @@ class TestFileDiscoveryService:
                     "par": Path("/test/J1857+0943.par"),
                     "tim": Path("/test/J1857+0943.tim"),
                     "timing_package": "tempo2",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "par_content": "PSR J1857+0943\nRAJ 18:57:36.4\nDECJ 09:43:17.1\n",
                 }
             ]
@@ -121,7 +122,7 @@ class TestFileDiscoveryService:
                     "par": Path("/test/J1857+0943.par"),
                     "tim": Path("/test/J1857+0943.tim"),
                     "timing_package": "tempo2",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                 }
             ]
 
@@ -143,7 +144,7 @@ class TestFileDiscoveryService:
                         "par": Path("test1.par"),
                         "tim": Path("test1.tim"),
                         "timing_package": "tempo2",
-                        "timespan_days": 1000.0,
+                        "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     }
                 ],
                 "ppta_dr2": [],
@@ -292,9 +293,7 @@ class TestFileDiscoveryService:
 
     @patch("pathlib.Path.exists")
     @patch("pathlib.Path.rglob")
-    @patch(
-        "metapulsar.file_discovery_service.FileDiscoveryService._calculate_timespan_and_count_from_tim_file"
-    )
+    @patch("metapulsar.file_discovery_service.FileDiscoveryService._get_tim_metadata")
     @patch("pathlib.Path.read_text")
     def test_discover_all_file_pairs_in_config_success(
         self, mock_read_text, mock_timespan, mock_rglob, mock_exists
@@ -310,7 +309,9 @@ class TestFileDiscoveryService:
         mock_read_text.return_value = (
             "PSR J1857+0943\nRAJ 18:57:36.4\nDECJ 09:43:17.1\n"
         )
-        mock_timespan.return_value = (1000.0, 500)
+        mock_timespan.return_value = make_tim_metadata(
+            timespan_days=1000.0, toa_count=500
+        )
 
         config = {
             "base_dir": "/test",
@@ -324,8 +325,8 @@ class TestFileDiscoveryService:
         assert len(result) == 1
         assert result[0]["par"] == Path("/test/J1857+0943.par")
         assert result[0]["tim"] == Path("/test/J1857+0943.tim")
-        assert result[0]["timespan_days"] == 1000.0
-        assert result[0]["toa_count"] == 500
+        assert result[0]["tim_metadata"].timespan_days == 1000.0
+        assert result[0]["tim_metadata"].toa_count == 500
 
     @patch("pathlib.Path.exists")
     def test_discover_all_file_pairs_in_config_no_base_dir(self, mock_exists):
@@ -413,7 +414,7 @@ class TestPulsarHelperFunctions:
                     "par": "test/J0613-0200.par",
                     "tim": "test/J0613-0200.tim",
                     "par_content": "PSR J0613-0200\nRAJ 06:13:43.9754\nDECJ -02:00:47.1755\n",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ],
@@ -422,7 +423,7 @@ class TestPulsarHelperFunctions:
                     "par": "test/J1857+0943.par",
                     "tim": "test/J1857+0943.tim",
                     "par_content": "PSR J1857+0943\nRAJ 18:57:36.3907\nDECJ +09:43:17.2070\n",
-                    "timespan_days": 1200.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1200.0),
                     "timing_package": "tempo2",
                 }
             ],
@@ -465,7 +466,7 @@ class TestPulsarHelperFunctions:
                     "par": "test/J0613-0200.par",
                     "tim": "test/J0613-0200.tim",
                     "par_content": "PSR J0613-0200\nRAJ 06:13:43.9754\nDECJ -02:00:47.1755\n",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ],
@@ -474,7 +475,7 @@ class TestPulsarHelperFunctions:
                     "par": "test/J1857+0943.par",
                     "tim": "test/J1857+0943.tim",
                     "par_content": "PSR J1857+0943\nRAJ 18:57:36.3907\nDECJ +09:43:17.2070\n",
-                    "timespan_days": 1200.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1200.0),
                     "timing_package": "tempo2",
                 }
             ],
@@ -517,7 +518,7 @@ class TestPulsarHelperFunctions:
                     "par": "test/J0613-0200.par",
                     "tim": "test/J0613-0200.tim",
                     "par_content": "PSR J0613-0200\nRAJ 06:13:43.9754\nDECJ -02:00:47.1755\n",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ],
@@ -526,7 +527,7 @@ class TestPulsarHelperFunctions:
                     "par": "test/J1857+0943.par",
                     "tim": "test/J1857+0943.tim",
                     "par_content": "PSR J1857+0943\nRAJ 18:57:36.3907\nDECJ +09:43:17.2070\n",
-                    "timespan_days": 1200.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1200.0),
                     "timing_package": "tempo2",
                 }
             ],
@@ -575,7 +576,7 @@ class TestPulsarHelperFunctions:
                     "par": "test/J0613-0200.par",
                     "tim": "test/J0613-0200.tim",
                     "par_content": "PSR J0613-0200\nRAJ 06:13:43.9754\nDECJ -02:00:47.1755\n",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ]
@@ -614,7 +615,7 @@ class TestPulsarHelperFunctions:
                     "par": "test/J0613-0200.par",
                     "tim": "test/J0613-0200.tim",
                     "par_content": "PSR J0613-0200\nRAJ 06:13:43.9754\nDECJ -02:00:47.1755\n",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ],
@@ -623,7 +624,7 @@ class TestPulsarHelperFunctions:
                     "par": "test/J1857+0943.par",
                     "tim": "test/J1857+0943.tim",
                     "par_content": "PSR J1857+0943\nRAJ 18:57:36.3907\nDECJ +09:43:17.2070\n",
-                    "timespan_days": 1200.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1200.0),
                     "timing_package": "tempo2",
                 }
             ],
@@ -670,7 +671,7 @@ class TestPulsarHelperFunctions:
                     "par": "test/J0613-0200.par",
                     "tim": "test/J0613-0200.tim",
                     "par_content": "PSR J0613-0200\nRAJ 06:13:43.9754\nDECJ -02:00:47.1755\n",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ]
@@ -725,7 +726,7 @@ class TestPulsarHelperFunctions:
                     "par": "test/J0613-0200.par",
                     "tim": "test/J0613-0200.tim",
                     "par_content": "PSR J0613-0200\nRAJ 06:13:43.9754\nDECJ -02:00:47.1755\n",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ]

--- a/tests/test_metapulsar_factory.py
+++ b/tests/test_metapulsar_factory.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 from metapulsar.metapulsar_factory import MetaPulsarFactory
 from metapulsar.file_discovery_service import FileDiscoveryService
+from tests.helpers import make_tim_metadata
 
 
 class TestParfileContentValidation:
@@ -23,7 +24,7 @@ class TestParfileContentValidation:
                 {
                     "par": "data/ipta-dr2/PPTA_dr1dr2/par/J1857+0943_dr1dr2.par",
                     "tim": "data/ipta-dr2/PPTA_dr1dr2/tim/J1857+0943_dr1dr2.tim",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ]
@@ -46,7 +47,7 @@ class TestParfileContentValidation:
                     "par": "data/ipta-dr2/PPTA_dr1dr2/par/J1857+0943_dr1dr2.par",
                     "tim": "data/ipta-dr2/PPTA_dr1dr2/tim/J1857+0943_dr1dr2.tim",
                     "par_content": "PSR J1857+0943\nF0 186.494081\n",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ]
@@ -68,7 +69,7 @@ class TestParfileContentValidation:
             "test_pta": [
                 {
                     "tim": "data/ipta-dr2/PPTA_dr1dr2/tim/J1857+0943_dr1dr2.tim",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ]
@@ -86,7 +87,7 @@ class TestParfileContentValidation:
                 {
                     "par": "non_existent_file.par",
                     "tim": "data/ipta-dr2/PPTA_dr1dr2/tim/J1857+0943_dr1dr2.tim",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ]
@@ -337,7 +338,7 @@ class TestMetaPulsarFactory:
                     "par": Path("/data/epta/J1857+0943.par"),
                     "tim": Path("/data/epta/J1857+0943.tim"),
                     "timing_package": "pint",
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "par_content": "PSR J1857+0943\nF0 123.456\nRAJ 18:57:36.4\nDECJ 9:43:17.2\n",
                 }
             ]
@@ -381,7 +382,7 @@ class TestMetaPulsarFactory:
                 "par": Path("/data/epta/J1857+0943.par"),
                 "tim": Path("/data/epta/J1857+0943.tim"),
                 "timing_package": "pint",
-                "timespan_days": 1000.0,
+                "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                 "par_content": "PSR J1857+0943\nF0 123.456\n",
             }
         }
@@ -419,7 +420,7 @@ class TestMetaPulsarFactory:
                 "par": Path("/data/epta/J1857+0943.par"),
                 "tim": Path("/data/epta/J1857+0943.tim"),
                 "timing_package": "tempo2",
-                "timespan_days": 1000.0,
+                "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                 "par_content": "PSR J1857+0943\nF0 123.456\n",
             }
         }
@@ -511,14 +512,14 @@ class TestPerPulsarOrdering:
                 {
                     "par": Path("test1.par"),
                     "tim": Path("test1.tim"),
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                 }
             ],
             "ppta_dr2": [
                 {
                     "par": Path("test2.par"),
                     "tim": Path("test2.tim"),
-                    "timespan_days": 2000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=2000.0),
                 }
             ],
         }
@@ -550,14 +551,14 @@ class TestPerPulsarOrdering:
                 {
                     "par": Path("test1.par"),
                     "tim": Path("test1.tim"),
-                    "timespan_days": 2000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=2000.0),
                 }
             ],
             "ppta_dr2": [
                 {
                     "par": Path("test2.par"),
                     "tim": Path("test2.tim"),
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                 }
             ],
         }
@@ -588,14 +589,14 @@ class TestPerPulsarOrdering:
                 {
                     "par": Path("test1.par"),
                     "tim": Path("test1.tim"),
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                 }
             ],
             "ppta_dr2": [
                 {
                     "par": Path("test2.par"),
                     "tim": Path("test2.tim"),
-                    "timespan_days": 2000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=2000.0),
                 }
             ],
         }
@@ -627,21 +628,21 @@ class TestPerPulsarOrdering:
                 {
                     "par": Path("test1.par"),
                     "tim": Path("test1.tim"),
-                    "timespan_days": 1000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                 }
             ],
             "ppta_dr2": [
                 {
                     "par": Path("test2.par"),
                     "tim": Path("test2.tim"),
-                    "timespan_days": 2000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=2000.0),
                 }
             ],
             "nanograv_12y": [
                 {
                     "par": Path("test3.par"),
                     "tim": Path("test3.tim"),
-                    "timespan_days": 1500.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=1500.0),
                 }
             ],
         }
@@ -659,7 +660,7 @@ class TestPerPulsarOrdering:
                 {
                     "par": Path("test2.par"),
                     "tim": Path("test2.tim"),
-                    "timespan_days": 2000.0,
+                    "tim_metadata": make_tim_metadata(timespan_days=2000.0),
                 }
             ],
         }
@@ -707,16 +708,18 @@ class TestPerPulsarOrdering:
                 {
                     "par": Path("test1.par"),
                     "tim": Path("test1.tim"),
-                    "timespan_days": 1000.0,
-                    "toa_count": 500,
+                    "tim_metadata": make_tim_metadata(
+                        timespan_days=1000.0, toa_count=500
+                    ),
                 }
             ],
             "ppta_dr2": [
                 {
                     "par": Path("test2.par"),
                     "tim": Path("test2.tim"),
-                    "timespan_days": 2000.0,
-                    "toa_count": 1000,
+                    "tim_metadata": make_tim_metadata(
+                        timespan_days=2000.0, toa_count=1000
+                    ),
                 }
             ],
         }
@@ -752,3 +755,112 @@ class TestPerPulsarOrdering:
                     # Check that the file_data passed to create_metapulsar has PPTA first
                     file_data_passed = call_args[1]["file_data"]
                     assert list(file_data_passed.keys())[0] == "ppta_dr2"
+
+
+class TestPtaSummary:
+    """Tests for PTA summary display including pulse-number coverage."""
+
+    def test_pta_summary_shows_pn_status(self, capsys):
+        factory = MetaPulsarFactory()
+        file_data = {
+            "epta_dr2": [
+                {
+                    "par": Path("test1.par"),
+                    "tim": Path("test1.tim"),
+                    "par_content": "PSR J1857+0943\nRAJ 18:57:36.4\nDECJ 09:43:17.1\n",
+                    "timing_package": "tempo2",
+                    "tim_metadata": make_tim_metadata(
+                        timespan_days=1000.0,
+                        toa_count=100,
+                        pn_status="complete",
+                        pn_with_count=100,
+                        pn_without_count=0,
+                    ),
+                }
+            ],
+            "ppta_dr2": [
+                {
+                    "par": Path("test2.par"),
+                    "tim": Path("test2.tim"),
+                    "par_content": "PSR J1857+0943\nRAJ 18:57:36.4\nDECJ 09:43:17.1\n",
+                    "timing_package": "tempo2",
+                    "tim_metadata": make_tim_metadata(
+                        timespan_days=2000.0,
+                        toa_count=200,
+                        pn_status="mixed",
+                        pn_with_count=120,
+                        pn_without_count=80,
+                    ),
+                }
+            ],
+        }
+
+        with (
+            patch(
+                "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized"
+            ) as mock_discover,
+            patch.object(
+                factory, "_get_display_name_for_pulsar", return_value="J1857+0943"
+            ),
+        ):
+            mock_discover.return_value = {
+                "J1857+0943": {
+                    "epta_dr2": file_data["epta_dr2"],
+                    "ppta_dr2": file_data["ppta_dr2"],
+                }
+            }
+            factory.pta_summary(file_data)
+
+        captured = capsys.readouterr().out
+        assert "pn=complete (100/100)" in captured
+        assert "pn=mixed (120/200)" in captured
+
+    def test_pta_summary_aggregates_pn_across_files(self, capsys):
+        factory = MetaPulsarFactory()
+        file_data = {
+            "epta_dr2": [
+                {
+                    "par": Path("test1.par"),
+                    "tim": Path("test1.tim"),
+                    "par_content": "PSR J1857+0943\nRAJ 18:57:36.4\nDECJ 09:43:17.1\n",
+                    "timing_package": "tempo2",
+                    "tim_metadata": make_tim_metadata(
+                        timespan_days=1000.0,
+                        toa_count=100,
+                        pn_status="complete",
+                        pn_with_count=100,
+                        pn_without_count=0,
+                    ),
+                },
+                {
+                    "par": Path("test1b.par"),
+                    "tim": Path("test1b.tim"),
+                    "par_content": "PSR J1857+0943\nRAJ 18:57:36.4\nDECJ 09:43:17.1\n",
+                    "timing_package": "tempo2",
+                    "tim_metadata": make_tim_metadata(
+                        timespan_days=800.0,
+                        toa_count=50,
+                        pn_status="none",
+                        pn_with_count=0,
+                        pn_without_count=50,
+                    ),
+                },
+            ],
+        }
+
+        with (
+            patch(
+                "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized"
+            ) as mock_discover,
+            patch.object(
+                factory, "_get_display_name_for_pulsar", return_value="J1857+0943"
+            ),
+        ):
+            mock_discover.return_value = {
+                "J1857+0943": {"epta_dr2": file_data["epta_dr2"]},
+            }
+            factory.pta_summary(file_data)
+
+        captured = capsys.readouterr().out
+        assert "150 TOAs" in captured
+        assert "pn=mixed (100/150)" in captured

--- a/tests/test_metapulsar_factory.py
+++ b/tests/test_metapulsar_factory.py
@@ -382,6 +382,7 @@ class TestMetaPulsarFactory:
                 "tim": Path("/data/epta/J1857+0943.tim"),
                 "timing_package": "pint",
                 "timespan_days": 1000.0,
+                "par_content": "PSR J1857+0943\nF0 123.456\n",
             }
         }
 
@@ -393,7 +394,7 @@ class TestMetaPulsarFactory:
             mock_get_model.return_value = (mock_model, mock_toas)
 
             result = self.factory._create_pulsar_objects(
-                file_pairs, file_data, use_pulse_numbers=False
+                file_pairs, file_data, use_pulse_numbers="no"
             )
 
             assert "epta_dr2" in result
@@ -419,6 +420,7 @@ class TestMetaPulsarFactory:
                 "tim": Path("/data/epta/J1857+0943.tim"),
                 "timing_package": "tempo2",
                 "timespan_days": 1000.0,
+                "par_content": "PSR J1857+0943\nF0 123.456\n",
             }
         }
 
@@ -427,7 +429,7 @@ class TestMetaPulsarFactory:
             mock_tempopulsar.return_value = mock_psr
 
             result = self.factory._create_pulsar_objects(
-                file_pairs, file_data, use_pulse_numbers=False
+                file_pairs, file_data, use_pulse_numbers="no"
             )
 
             assert "epta_dr2" in result
@@ -436,6 +438,63 @@ class TestMetaPulsarFactory:
                 parfile=str(file_pairs["epta_dr2"][0]),
                 timfile=str(file_pairs["epta_dr2"][1]),
                 dofit=False,
+            )
+
+    def test_create_pulsar_objects_tempo2_yes_uses_track_minus_2(self, tmp_path):
+        """Tempo2 yes mode wraps par with TRACK -2."""
+        par_path = tmp_path / "test.par"
+        tim_path = tmp_path / "test.tim"
+        par_path.write_text("PSR J1857+0943\nF0 123.456\n", encoding="utf-8")
+        tim_path.write_text("FORMAT 1\nMODE 1\n", encoding="utf-8")
+
+        file_pairs = {"epta_dr2": (par_path, tim_path)}
+        file_data = {
+            "epta_dr2": {
+                "par": par_path,
+                "tim": tim_path,
+                "timing_package": "tempo2",
+                "par_content": par_path.read_text(encoding="utf-8"),
+            }
+        }
+
+        with (
+            patch(
+                "metapulsar.metapulsar_factory.resolved_tim_for_pulse_numbers"
+            ) as mock_resolved,
+            patch(
+                "metapulsar.metapulsar_factory.temporary_par_with_track_minus_2"
+            ) as mock_track_par,
+            patch("metapulsar.metapulsar_factory.tempopulsar") as mock_tempopulsar,
+        ):
+            mock_resolved.return_value.__enter__.return_value = str(tim_path)
+            mock_track_par.return_value.__enter__.return_value = "/tmp/track.par"
+            mock_tempopulsar.return_value = Mock()
+
+            self.factory._create_pulsar_objects(
+                file_pairs, file_data, use_pulse_numbers="yes"
+            )
+
+            mock_track_par.assert_called_once()
+            mock_tempopulsar.assert_called_once_with(
+                parfile="/tmp/track.par",
+                timfile=str(tim_path),
+                dofit=False,
+            )
+
+    def test_validate_pulse_number_mode_rejects_bool(self):
+        with pytest.raises(ValueError, match="must be one of"):
+            self.factory.create_metapulsar(
+                {
+                    "pta": [
+                        {
+                            "par": Path("x.par"),
+                            "tim": Path("x.tim"),
+                            "timing_package": "pint",
+                            "par_content": "PSR J0000+0000\nF0 1\n",
+                        }
+                    ]
+                },
+                use_pulse_numbers=True,  # type: ignore[arg-type]
             )
 
 

--- a/tests/test_metapulsar_with_parameter_manager.py
+++ b/tests/test_metapulsar_with_parameter_manager.py
@@ -5,6 +5,7 @@ from pint.models import TimingModel
 from pint.toa import TOAs
 from metapulsar.metapulsar import MetaPulsar
 from metapulsar.parameter_manager import ParameterManager
+from tests.helpers import make_tim_metadata
 
 
 class TestMetaPulsarWithParameterManager:
@@ -58,11 +59,11 @@ class TestMetaPulsarWithParameterManager:
         # Test ParameterManager initialization directly
         mock_file_data = {
             "epta_dr2": {
-                "timespan_days": 1000,
+                "tim_metadata": make_tim_metadata(timespan_days=1000),
                 "par_content": "PSR J1857+0943\nF0 123.456\n",
             },
             "ppta_dr2": {
-                "timespan_days": 1200,
+                "tim_metadata": make_tim_metadata(timespan_days=1200),
                 "par_content": "PSR J1857+0943\nF0 123.456\n",
             },
         }
@@ -82,11 +83,11 @@ class TestMetaPulsarWithParameterManager:
         # Test ParameterManager initialization directly
         mock_file_data = {
             "epta_dr2": {
-                "timespan_days": 1000,
+                "tim_metadata": make_tim_metadata(timespan_days=1000),
                 "par_content": "PSR J1857+0943\nF0 123.456\n",
             },
             "ppta_dr2": {
-                "timespan_days": 1200,
+                "tim_metadata": make_tim_metadata(timespan_days=1200),
                 "par_content": "PSR J1857+0943\nF0 123.456\n",
             },
         }

--- a/tests/test_parameter_manager.py
+++ b/tests/test_parameter_manager.py
@@ -15,6 +15,7 @@ from metapulsar.parameter_manager import (
     ParameterInconsistencyError,
     ParameterMapping,
 )
+from tests.helpers import make_tim_metadata
 
 # Mark all tests as slow
 pytestmark = pytest.mark.slow
@@ -30,21 +31,21 @@ class TestParameterManager:
             "EPTA": {
                 "par": Path("test_parfiles/epta.par"),
                 "tim": Path("test_parfiles/epta.tim"),
-                "timespan_days": 3650.5,
+                "tim_metadata": make_tim_metadata(timespan_days=3650.5),
                 "timing_package": "pint",
                 "par_content": "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\nF1 -6.2e-16\nRAJ 18:57:36.3937\nDECJ +09:43:17.291\nDM 13.299\nUNITS TDB\n",
             },
             "PPTA": {
                 "par": Path("test_parfiles/ppta.par"),
                 "tim": Path("test_parfiles/ppta.tim"),
-                "timespan_days": 4200.3,
+                "tim_metadata": make_tim_metadata(timespan_days=4200.3),
                 "timing_package": "tempo2",
                 "par_content": "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\nF1 -6.2e-16\nRAJ 18:57:36.3937\nDECJ +09:43:17.291\nDM 13.299\nUNITS TDB\n",
             },
             "NANOGrav": {
                 "par": Path("test_parfiles/nanograv.par"),
                 "tim": Path("test_parfiles/nanograv.tim"),
-                "timespan_days": 2800.1,
+                "tim_metadata": make_tim_metadata(timespan_days=2800.1),
                 "timing_package": "pint",
                 "par_content": "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\nF1 -6.2e-16\nRAJ 18:57:36.3937\nDECJ +09:43:17.291\nDM 13.299\nUNITS TDB\n",
             },
@@ -400,14 +401,14 @@ UNITS TDB
             "EPTA": {
                 "par": Path("test_parfiles/epta.par"),
                 "tim": Path("test_parfiles/epta.tim"),
-                "timespan_days": 3650.5,
+                "tim_metadata": make_tim_metadata(timespan_days=3650.5),
                 "timing_package": "pint",
                 "par_content": "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\nF1 -6.2e-16\nRAJ 18:57:36.3937\nDECJ +09:43:17.291\nUNITS TDB\n",
             },
             "PPTA": {
                 "par": Path("test_parfiles/ppta.par"),
                 "tim": Path("test_parfiles/ppta.tim"),
-                "timespan_days": 4200.3,
+                "tim_metadata": make_tim_metadata(timespan_days=4200.3),
                 "timing_package": "tempo2",
                 "par_content": "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\nF1 -6.2e-16\nRAJ 18:57:36.3937\nDECJ +09:43:17.291\nUNITS TDB\n",
             },

--- a/tests/test_pint_helpers.py
+++ b/tests/test_pint_helpers.py
@@ -624,3 +624,45 @@ T0 55000.0 1
             # Should still call ModelBuilder
             mock_builder.assert_called_once()
             assert result == mock_model
+
+
+class TestAstrometryStyleDetection:
+    """Test alias-driven astrometry style detection helpers."""
+
+    def test_has_parameter_alias_accepts_pint_aliases(self):
+        from metapulsar.pint_helpers import has_parameter_alias
+
+        parfile_dict = {"LAMBDA": ["244.347"], "BETA": ["-10.07"]}
+        assert has_parameter_alias(parfile_dict, "ELONG")
+        assert has_parameter_alias(parfile_dict, "ELAT")
+        assert not has_parameter_alias(parfile_dict, "RAJ")
+
+    def test_detect_astrometry_style_equatorial_aliases(self):
+        from metapulsar.pint_helpers import detect_astrometry_style
+
+        parfile_dict = {
+            "RA": ["18:57:36.3937"],
+            "DEC": ["+09:43:17.291"],
+        }
+        assert detect_astrometry_style(parfile_dict) == "equatorial"
+
+    def test_detect_astrometry_style_ecliptic_aliases(self):
+        from metapulsar.pint_helpers import detect_astrometry_style
+
+        parfile_dict = {
+            "ELONG": ["244.347"],
+            "ELAT": ["-10.07"],
+        }
+        assert detect_astrometry_style(parfile_dict) == "ecliptic"
+
+    def test_detect_astrometry_style_mixed_raises(self):
+        from metapulsar.pint_helpers import detect_astrometry_style
+
+        parfile_dict = {
+            "RAJ": ["18:57:36.3937"],
+            "DECJ": ["+09:43:17.291"],
+            "LAMBDA": ["244.347"],
+            "BETA": ["-10.07"],
+        }
+        with pytest.raises(ValueError, match="Mixed astrometry detected"):
+            detect_astrometry_style(parfile_dict)

--- a/tests/test_pulse_number_helpers.py
+++ b/tests/test_pulse_number_helpers.py
@@ -7,11 +7,11 @@ import pytest
 
 from metapulsar.pint_helpers import (
     PULSE_NUMBER_MODES,
-    classify_tim_pulse_numbers,
     sanitize_tempo2_tim_noise_directives,
     validate_pulse_number_mode,
     _should_derive_pulse_numbers,
 )
+from metapulsar.tim_file_analyzer import TimFileAnalyzer
 
 
 class TestValidatePulseNumberMode:
@@ -53,7 +53,7 @@ class TestSanitizeTempo2TimNoiseDirectives:
         assert sanitize_tempo2_tim_noise_directives(raw) == raw
 
 
-class TestClassifyTimPulseNumbers:
+class TestTimMetadataPnClassification:
     def test_complete_when_all_toas_have_pn(self, tmp_path):
         tim = tmp_path / "all_pn.tim"
         tim.write_text(
@@ -63,10 +63,10 @@ class TestClassifyTimPulseNumbers:
             " obs2 1400.0 58001.0 1.0 g -pn 1\n",
             encoding="utf-8",
         )
-        status, n_with, n_without = classify_tim_pulse_numbers(tim)
-        assert status == "complete"
-        assert n_with == 2
-        assert n_without == 0
+        meta = TimFileAnalyzer().get_tim_metadata(tim)
+        assert meta.pn_status == "complete"
+        assert meta.pn_with_count == 2
+        assert meta.pn_without_count == 0
 
     def test_none_when_no_pn(self, tmp_path):
         tim = tmp_path / "no_pn.tim"
@@ -77,10 +77,10 @@ class TestClassifyTimPulseNumbers:
             " obs2 1400.0 58001.0 1.0 g\n",
             encoding="utf-8",
         )
-        status, n_with, n_without = classify_tim_pulse_numbers(tim)
-        assert status == "none"
-        assert n_with == 0
-        assert n_without == 2
+        meta = TimFileAnalyzer().get_tim_metadata(tim)
+        assert meta.pn_status == "none"
+        assert meta.pn_with_count == 0
+        assert meta.pn_without_count == 2
 
     def test_mixed_when_partial_pn(self, tmp_path):
         tim = tmp_path / "mixed_pn.tim"
@@ -91,10 +91,10 @@ class TestClassifyTimPulseNumbers:
             " obs2 1400.0 58001.0 1.0 g\n",
             encoding="utf-8",
         )
-        status, n_with, n_without = classify_tim_pulse_numbers(tim)
-        assert status == "mixed"
-        assert n_with == 1
-        assert n_without == 1
+        meta = TimFileAnalyzer().get_tim_metadata(tim)
+        assert meta.pn_status == "mixed"
+        assert meta.pn_with_count == 1
+        assert meta.pn_without_count == 1
 
 
 class TestShouldDerivePulseNumbers:

--- a/tests/test_pulse_number_helpers.py
+++ b/tests/test_pulse_number_helpers.py
@@ -1,0 +1,240 @@
+"""Tests for pulse-number mode helpers."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from metapulsar.pint_helpers import (
+    PULSE_NUMBER_MODES,
+    classify_tim_pulse_numbers,
+    sanitize_tempo2_tim_noise_directives,
+    validate_pulse_number_mode,
+    _should_derive_pulse_numbers,
+)
+
+
+class TestValidatePulseNumberMode:
+    def test_accepts_valid_modes(self):
+        for mode in PULSE_NUMBER_MODES:
+            assert validate_pulse_number_mode(mode) == mode
+
+    def test_normalizes_case(self):
+        assert validate_pulse_number_mode("YES") == "yes"
+
+    def test_rejects_bool(self):
+        with pytest.raises(ValueError, match="must be one of"):
+            validate_pulse_number_mode(True)
+
+    def test_rejects_unknown(self):
+        with pytest.raises(ValueError, match="must be one of"):
+            validate_pulse_number_mode("maybe")
+
+
+class TestSanitizeTempo2TimNoiseDirectives:
+    def test_strips_t2e_and_tne_lines(self):
+        raw = (
+            "FORMAT 1\n"
+            "MODE 1\n"
+            "T2EFAC -sys GM_GWB_500_100_b1 3.04\n"
+            "T2EQUAD -sys foo 1.0\n"
+            "TNEQUAD -sys bar 2.0\n"
+            " obs1 1400.0 58000.0 1.0 g -pn 0\n"
+        )
+        out = sanitize_tempo2_tim_noise_directives(raw)
+        assert "T2EFAC" not in out
+        assert "T2EQUAD" not in out
+        assert "TNEQUAD" not in out
+        assert "FORMAT 1" in out
+        assert "-pn 0" in out
+
+    def test_preserves_comments(self):
+        raw = "C comment\n# also\nMODE 1\n"
+        assert sanitize_tempo2_tim_noise_directives(raw) == raw
+
+
+class TestClassifyTimPulseNumbers:
+    def test_complete_when_all_toas_have_pn(self, tmp_path):
+        tim = tmp_path / "all_pn.tim"
+        tim.write_text(
+            "FORMAT 1\n"
+            "MODE 1\n"
+            " obs1 1400.0 58000.0 1.0 g -pn 0\n"
+            " obs2 1400.0 58001.0 1.0 g -pn 1\n",
+            encoding="utf-8",
+        )
+        status, n_with, n_without = classify_tim_pulse_numbers(tim)
+        assert status == "complete"
+        assert n_with == 2
+        assert n_without == 0
+
+    def test_none_when_no_pn(self, tmp_path):
+        tim = tmp_path / "no_pn.tim"
+        tim.write_text(
+            "FORMAT 1\n"
+            "MODE 1\n"
+            " obs1 1400.0 58000.0 1.0 g\n"
+            " obs2 1400.0 58001.0 1.0 g\n",
+            encoding="utf-8",
+        )
+        status, n_with, n_without = classify_tim_pulse_numbers(tim)
+        assert status == "none"
+        assert n_with == 0
+        assert n_without == 2
+
+    def test_mixed_when_partial_pn(self, tmp_path):
+        tim = tmp_path / "mixed_pn.tim"
+        tim.write_text(
+            "FORMAT 1\n"
+            "MODE 1\n"
+            " obs1 1400.0 58000.0 1.0 g -pn 0\n"
+            " obs2 1400.0 58001.0 1.0 g\n",
+            encoding="utf-8",
+        )
+        status, n_with, n_without = classify_tim_pulse_numbers(tim)
+        assert status == "mixed"
+        assert n_with == 1
+        assert n_without == 1
+
+
+class TestShouldDerivePulseNumbers:
+    def test_no_never_derives(self):
+        assert not _should_derive_pulse_numbers("no", "complete", Path("x.tim"), 2, 0)
+
+    def test_overwrite_always_derives(self):
+        assert _should_derive_pulse_numbers(
+            "overwrite", "complete", Path("x.tim"), 2, 0
+        )
+
+    def test_yes_complete_no_derive(self):
+        assert not _should_derive_pulse_numbers("yes", "complete", Path("x.tim"), 2, 0)
+
+    def test_yes_none_derives_without_warning(self):
+        with patch("metapulsar.pint_helpers.loguru_logger") as mock_log:
+            assert _should_derive_pulse_numbers("yes", "none", Path("x.tim"), 0, 2)
+            mock_log.warning.assert_not_called()
+
+    def test_reuse_none_warns_and_derives(self):
+        with patch("metapulsar.pint_helpers.loguru_logger") as mock_log:
+            assert _should_derive_pulse_numbers("reuse", "none", Path("x.tim"), 0, 2)
+            mock_log.warning.assert_called_once()
+
+    def test_yes_mixed_warns_and_derives(self):
+        with patch("metapulsar.pint_helpers.loguru_logger") as mock_log:
+            assert _should_derive_pulse_numbers("yes", "mixed", Path("x.tim"), 1, 1)
+            mock_log.warning.assert_called_once()
+
+
+class TestResolvedTimReusesCompletePn:
+    @staticmethod
+    def _complete_pn_tim(tmp_path: Path) -> Path:
+        tim = tmp_path / "complete_pn.tim"
+        tim.write_text(
+            "FORMAT 1\n"
+            "MODE 1\n"
+            " obs1 1400.0 58000.0 1.0 g -pn 0\n"
+            " obs2 1400.0 58001.0 1.0 g -pn 1\n",
+            encoding="utf-8",
+        )
+        return tim
+
+    def test_reuse_complete_pn_skips_pint_derivation(self, tmp_path):
+        from metapulsar.pint_helpers import resolved_tim_for_pulse_numbers
+
+        tim_path = self._complete_pn_tim(tmp_path)
+        par_text = "PSR J0000+0000\nF0 1.0\n"
+
+        with (
+            patch(
+                "metapulsar.pint_helpers.temporary_pn_tim_from_par_tim_pint"
+            ) as mock_pint,
+            patch(
+                "metapulsar.pint_helpers.temporary_pn_tim_from_par_tim_tempo2"
+            ) as mock_tempo2,
+        ):
+            with resolved_tim_for_pulse_numbers(
+                "reuse",
+                par_text,
+                tim_path,
+                derive_backend="pint",
+            ) as tim_out:
+                assert tim_out == str(tim_path)
+            mock_pint.assert_not_called()
+            mock_tempo2.assert_not_called()
+
+    def test_reuse_complete_pn_skips_tempo2_derivation(self, tmp_path):
+        from metapulsar.pint_helpers import resolved_tim_for_pulse_numbers
+
+        tim_path = self._complete_pn_tim(tmp_path)
+        par_text = "PSR J0000+0000\nF0 1.0\n"
+
+        with (
+            patch(
+                "metapulsar.pint_helpers.temporary_pn_tim_from_par_tim_pint"
+            ) as mock_pint,
+            patch(
+                "metapulsar.pint_helpers.temporary_pn_tim_from_par_tim_tempo2"
+            ) as mock_tempo2,
+        ):
+            with resolved_tim_for_pulse_numbers(
+                "reuse",
+                par_text,
+                tim_path,
+                derive_backend="tempo2",
+            ) as tim_out:
+                assert tim_out == str(tim_path)
+            mock_pint.assert_not_called()
+            mock_tempo2.assert_not_called()
+
+
+class TestParTextWithTrackMinus2:
+    def test_injects_track_without_reserializing_tempo2_fit_flags(self):
+        from metapulsar.pint_helpers import par_text_with_track_minus_2
+
+        par = "PSR J0000+0000\nDM 120 0 0 Y\nF0 300 0 0 N\n"
+        out = par_text_with_track_minus_2(par)
+        assert "TRACK -2" in out
+        assert "DM 120 0 0 Y" in out
+        assert "F0 300 0 0 N" in out
+
+    def test_replaces_existing_track_line(self):
+        from metapulsar.pint_helpers import par_text_with_track_minus_2
+
+        par = "PSR J0000+0000\nTRACK 0\nF0 1\n"
+        out = par_text_with_track_minus_2(par)
+        assert "TRACK -2" in out
+        assert "TRACK 0" not in out
+
+
+class TestEnsurePintTrackMinus2:
+    def test_warns_when_track_missing(self):
+        from metapulsar.pint_helpers import ensure_pint_track_minus_2
+
+        class ModelWithoutTrack:
+            params = {}
+
+        with patch("metapulsar.pint_helpers.loguru_logger") as mock_log:
+            ensure_pint_track_minus_2(ModelWithoutTrack())  # type: ignore[arg-type]
+            mock_log.warning.assert_called_once()
+
+
+class TestTemporaryPnTimTempo2Sanitization:
+    def test_sanitizes_plugin_output(self, tmp_path):
+        from metapulsar.pint_helpers import temporary_pn_tim_from_par_tim_tempo2
+
+        par_text = "PSR J0030+0451\nF0 205.5307\n"
+        tim_path = tmp_path / "in.tim"
+        tim_path.write_text("FORMAT 1\nMODE 1\n", encoding="utf-8")
+
+        def fake_run(cmd, **kwargs):
+            cwd = Path(kwargs["cwd"])
+            (cwd / "withpn.tim").write_text(
+                "FORMAT 1\nMODE 1\nT2EFAC -sys foo 1.0\n obs1 1400.0 58000.0 1.0 g -pn 0\n",
+                encoding="utf-8",
+            )
+
+        with patch("metapulsar.pint_helpers.subprocess.run", side_effect=fake_run):
+            with temporary_pn_tim_from_par_tim_tempo2(par_text, tim_path) as pn_tim:
+                text = Path(pn_tim).read_text(encoding="utf-8")
+        assert "T2EFAC" not in text
+        assert "-pn 0" in text

--- a/tests/test_pulse_tracking.py
+++ b/tests/test_pulse_tracking.py
@@ -33,20 +33,20 @@ def _load_prefit_rms(par_path: Path, tim_path: Path) -> float:
     return float(np.sqrt(np.mean(residuals**2)))
 
 
-def _build_file_data():
+def _build_file_data(timing_package: str = "pint"):
     return {
         "epta_like": [
             {
                 "par": EPTA_PAR,
                 "tim": EPTA_TIM,
-                "timing_package": "pint",
+                "timing_package": timing_package,
             }
         ],
         "nanograv_like": [
             {
                 "par": NANOGRAV_PAR,
                 "tim": NANOGRAV_TIM,
-                "timing_package": "pint",
+                "timing_package": timing_package,
             }
         ],
     }
@@ -65,6 +65,7 @@ def _weighted_postfit_rms(metapulsar) -> float:
 
 
 @pytest.mark.unit
+@pytest.mark.slow
 def test_pulse_tracking_fixtures_are_individually_coherent():
     epta_rms = _load_prefit_rms(EPTA_PAR, EPTA_TIM)
     nanograv_rms = _load_prefit_rms(NANOGRAV_PAR, NANOGRAV_TIM)
@@ -74,17 +75,25 @@ def test_pulse_tracking_fixtures_are_individually_coherent():
 
 
 @pytest.mark.unit
-def test_pulse_tracking_recovers_coherent_postfit_solution():
-    file_data = _build_file_data()
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "timing_package",
+    [
+        "pint",
+        pytest.param("tempo2", marks=pytest.mark.requires_libstempo),
+    ],
+)
+def test_pulse_tracking_recovers_coherent_postfit_solution(timing_package):
+    file_data = _build_file_data(timing_package)
     factory = MetaPulsarFactory()
 
     metapulsar_without_pn = factory.create_metapulsar(
         file_data=file_data,
-        use_pulse_numbers=False,
+        use_pulse_numbers="no",
     )
     metapulsar_with_pn = factory.create_metapulsar(
         file_data=file_data,
-        use_pulse_numbers=True,
+        use_pulse_numbers="yes",
     )
 
     assert len(metapulsar_without_pn._toas) == EXPECTED_TOAS
@@ -94,13 +103,14 @@ def test_pulse_tracking_recovers_coherent_postfit_solution():
     postfit_with_pn = _weighted_postfit_rms(metapulsar_with_pn)
 
     assert postfit_with_pn <= COHERENT_POSTFIT_RMS_THRESHOLD_S, (
-        "Pulse-number-tracked fit did not recover a coherent post-fit solution. "
+        f"[{timing_package}] Pulse-number-tracked fit did not recover a coherent "
+        "post-fit solution. "
         f"threshold={COHERENT_POSTFIT_RMS_THRESHOLD_S:.3e}s "
         f"postfit_with_pn={postfit_with_pn:.3e}s"
     )
     assert postfit_without_pn >= INCOHERENT_POSTFIT_RMS_THRESHOLD_S, (
-        "Disabling pulse-number tracking did not produce the expected incoherent "
-        "post-fit solution. "
+        f"[{timing_package}] Disabling pulse-number tracking did not produce the "
+        "expected incoherent post-fit solution. "
         f"threshold={INCOHERENT_POSTFIT_RMS_THRESHOLD_S:.3e}s "
         f"postfit_without_pn={postfit_without_pn:.3e}s"
     )

--- a/tests/test_tim_file_analyzer.py
+++ b/tests/test_tim_file_analyzer.py
@@ -2,11 +2,6 @@
 
 import pytest
 from pathlib import Path
-import sys
-import os
-
-# Add src to path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from metapulsar.tim_file_analyzer import TimFileAnalyzer
 from pint.toa import _toa_format

--- a/tests/test_tim_file_analyzer.py
+++ b/tests/test_tim_file_analyzer.py
@@ -3,668 +3,293 @@
 import pytest
 from pathlib import Path
 
-from metapulsar.tim_file_analyzer import TimFileAnalyzer
-from pint.toa import _toa_format
+from metapulsar.tim_file_analyzer import TimFileAnalyzer, TimMetadata
+
+
+def _tempo2_line(mjd: float, *, pn=None, extra_flags: str = "") -> str:
+    """Create a FORMAT 1 TOA line (short, under 80 chars)."""
+    base = f" obs1 1400.0 {mjd} 1.0 g"
+    if pn is not None:
+        base += f" -pn {pn}"
+    if extra_flags:
+        base += f" {extra_flags}"
+    return base
 
 
 class TestTimFileAnalyzer:
-    """Test cases for TimFileAnalyzer class."""
+    """Test cases for TimFileAnalyzer.get_tim_metadata()."""
 
     def setup_method(self):
-        """Set up test fixtures before each test method."""
         self.analyzer = TimFileAnalyzer()
         self.test_data_dir = Path("tests/data/tim_files")
         self.test_data_dir.mkdir(parents=True, exist_ok=True)
 
     def teardown_method(self):
-        """Clean up after each test method."""
-        # Clean up any test files created
         if self.test_data_dir.exists():
             for file in self.test_data_dir.glob("*.tim"):
                 file.unlink()
             self.test_data_dir.rmdir()
 
     def _create_test_tim_file(self, filename: str, content: str) -> Path:
-        """Create a test TIM file with given content."""
         file_path = self.test_data_dir / filename
-        file_path.write_text(content)
+        file_path.write_text(content, encoding="utf-8")
         return file_path
 
-    def _create_tempo2_line(self, mjd: float) -> str:
-        """Create a properly formatted Tempo2 TOA line."""
-        return f"c036915.align.pazr.30min 1345.999 {mjd} 2.890 g -flag1 value1 -flag2 value2"
-
-    # Core Functionality Tests
-
-    def test_calculate_timespan_basic(self):
-        """Test basic timespan calculation with simple TIM file."""
+    def test_basic_timespan_and_count(self):
         content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-{self._create_tempo2_line(55093.1109722889085)}
+{_tempo2_line(55087.1109722889085)}
+{_tempo2_line(55090.1109722889085)}
+{_tempo2_line(55093.1109722889085)}
 """
         tim_file = self._create_test_tim_file("basic.tim", content)
+        meta = self.analyzer.get_tim_metadata(tim_file)
 
-        timespan = self.analyzer.calculate_timespan(tim_file)
+        assert meta.toa_count == 3
+        assert meta.timespan_days == pytest.approx(6.0)
+        assert meta.mjd_min == pytest.approx(55087.1109722889085)
+        assert meta.mjd_max == pytest.approx(55093.1109722889085)
+        assert meta.pn_status == "none"
+        assert meta.pn_without_count == 3
 
-        # Timespan should be 55093.1109722889085 - 55087.1109722889085 = 6.0 days
-        assert timespan == 6.0
-
-    def test_calculate_timespan_empty_file(self):
-        """Test handling of empty TIM file."""
+    def test_empty_file(self):
         tim_file = self._create_test_tim_file("empty.tim", "")
+        meta = self.analyzer.get_tim_metadata(tim_file)
 
-        timespan = self.analyzer.calculate_timespan(tim_file)
+        assert meta.toa_count == 0
+        assert meta.timespan_days == 0.0
+        assert meta.mjd_min is None
+        assert meta.pn_status == "none"
 
-        assert timespan == 0.0
-
-    def test_calculate_timespan_single_toa(self):
-        """Test file with only one TOA."""
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-"""
+    def test_single_toa_zero_timespan(self):
+        content = f"FORMAT 1\n{_tempo2_line(55087.1109722889085)}\n"
         tim_file = self._create_test_tim_file("single_toa.tim", content)
+        meta = self.analyzer.get_tim_metadata(tim_file)
 
-        timespan = self.analyzer.calculate_timespan(tim_file)
+        assert meta.toa_count == 1
+        assert meta.timespan_days == 0.0
 
-        assert timespan == 0.0
-
-    def test_calculate_timespan_missing_file(self):
-        """Test handling of non-existent file."""
+    def test_missing_file(self):
         missing_file = self.test_data_dir / "missing.tim"
+        meta = self.analyzer.get_tim_metadata(missing_file)
 
-        timespan = self.analyzer.calculate_timespan(missing_file)
+        assert meta.toa_count == 0
+        assert meta.timespan_days == 0.0
 
-        assert timespan == 0.0
-
-    # Format Detection Tests
-
-    def test_toa_format_tempo2(self):
-        """Test Tempo2 format detection."""
-        # Long line (>80 chars) should be detected as Tempo2
-        long_line = (
-            "c036915.align.pazr.30min 1345.999 55087.1109722889085 2.890 g " + "x" * 50
+    def test_short_format1_lines(self):
+        """Short FORMAT 1 lines (<80 chars) must be counted as TOAs."""
+        content = (
+            "FORMAT 1\n" " obs1 1400.0 58000.0 1.0 g\n" " obs2 1400.0 58001.0 1.0 g\n"
         )
-        assert _toa_format(long_line) == "Tempo2"
+        tim_file = self._create_test_tim_file("short_format1.tim", content)
+        meta = self.analyzer.get_tim_metadata(tim_file)
 
-    def test_toa_format_princeton(self):
-        """Test Princeton format detection."""
-        # Line starting with [0-9a-z@] followed by space should be Princeton
-        princeton_line = "a 1345.999 55087.1109722889085 2.890 g"
-        assert _toa_format(princeton_line) == "Princeton"
+        assert meta.toa_count == 2
+        assert meta.timespan_days == pytest.approx(1.0)
 
-    def test_toa_format_parkes(self):
-        """Test Parkes format detection."""
-        # Line starting with space and having decimal at column 42
-        parkes_line = " " * 41 + ".123456" + " " * 20
-        assert _toa_format(parkes_line) == "Parkes"
+    def test_pn_complete(self):
+        content = (
+            "FORMAT 1\n"
+            f"{_tempo2_line(58000.0, pn=0)}\n"
+            f"{_tempo2_line(58001.0, pn=1)}\n"
+        )
+        tim_file = self._create_test_tim_file("pn_complete.tim", content)
+        meta = self.analyzer.get_tim_metadata(tim_file)
 
-    def test_toa_format_comments(self):
-        """Test comment line detection."""
-        # Lines starting with #, C , CC should be comments
-        # Note: "c " (lowercase c with space) is detected as Princeton, not Comment
-        assert _toa_format("# This is a comment") == "Comment"
-        assert _toa_format("C This is a comment") == "Comment"
-        assert _toa_format("CC This is a comment") == "Comment"
+        assert meta.pn_status == "complete"
+        assert meta.pn_with_count == 2
+        assert meta.pn_without_count == 0
 
-    def test_toa_format_commands(self):
-        """Test command line detection."""
-        # Lines starting with FORMAT, JUMP, TIME, etc. should be commands
-        assert _toa_format("FORMAT 1") == "Command"
-        assert _toa_format("JUMP 55000 55001") == "Command"
-        assert _toa_format("TIME 55000") == "Command"
-        assert _toa_format("PHASE 0") == "Command"
-        assert _toa_format("SKIP") == "Command"
-        assert _toa_format("NOSKIP") == "Command"
+    def test_pn_none(self):
+        content = "FORMAT 1\n" f"{_tempo2_line(58000.0)}\n" f"{_tempo2_line(58001.0)}\n"
+        tim_file = self._create_test_tim_file("pn_none.tim", content)
+        meta = self.analyzer.get_tim_metadata(tim_file)
 
-    def test_toa_format_blank(self):
-        """Test blank line detection."""
-        # Empty or whitespace-only lines should be blank
-        assert _toa_format("") == "Blank"
-        assert _toa_format("   ") == "Blank"
-        assert _toa_format("\t") == "Blank"
+        assert meta.pn_status == "none"
+        assert meta.pn_with_count == 0
+        assert meta.pn_without_count == 2
 
-    def test_toa_format_unknown(self):
-        """Test unknown format detection."""
-        # Lines that don't match any pattern should be unknown
-        assert _toa_format("!@#$%^&*()") == "Unknown"
+    def test_pn_mixed(self):
+        content = (
+            "FORMAT 1\n" f"{_tempo2_line(58000.0, pn=0)}\n" f"{_tempo2_line(58001.0)}\n"
+        )
+        tim_file = self._create_test_tim_file("pn_mixed.tim", content)
+        meta = self.analyzer.get_tim_metadata(tim_file)
 
-    # INCLUDE Statement Tests
+        assert meta.pn_status == "mixed"
+        assert meta.pn_with_count == 1
+        assert meta.pn_without_count == 1
+
+    def test_long_line_with_extra_flags(self):
+        content = (
+            "FORMAT 1\n"
+            " c036915.align.pazr.30min 1345.999 55087.1109722889085 2.890 g "
+            "-flag1 value1 -pn 42 -group foo\n"
+        )
+        tim_file = self._create_test_tim_file("long_flags.tim", content)
+        meta = self.analyzer.get_tim_metadata(tim_file)
+
+        assert meta.toa_count == 1
+        assert meta.pn_status == "complete"
 
     def test_include_single_file(self):
-        """Test processing single INCLUDE statement."""
-        # Create main file with INCLUDE
         main_content = f"""FORMAT 1
 INCLUDE included.tim
-{self._create_tempo2_line(55087.1109722889085)}
+{_tempo2_line(55087.1109722889085)}
 """
-        included_content = f"""FORMAT 1
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-
+        included_content = f"FORMAT 1\n{_tempo2_line(55090.1109722889085)}\n"
         main_file = self._create_test_tim_file("main.tim", main_content)
         self._create_test_tim_file("included.tim", included_content)
 
-        timespan = self.analyzer.calculate_timespan(main_file)
-
-        # Should include TOAs from both files: 55090.1109722889085 - 55087.1109722889085 = 3.0 days
-        assert timespan == 3.0
+        meta = self.analyzer.get_tim_metadata(main_file)
+        assert meta.toa_count == 2
+        assert meta.timespan_days == pytest.approx(3.0)
 
     def test_include_multiple_files(self):
-        """Test processing multiple INCLUDE statements."""
         main_content = f"""FORMAT 1
 INCLUDE file1.tim
 INCLUDE file2.tim
-{self._create_tempo2_line(55087.1109722889085)}
+{_tempo2_line(55087.1109722889085)}
 """
-        file1_content = f"""FORMAT 1
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        file2_content = f"""FORMAT 1
-{self._create_tempo2_line(55093.1109722889085)}
-"""
-
+        self._create_test_tim_file(
+            "file1.tim", f"FORMAT 1\n{_tempo2_line(55090.1109722889085)}\n"
+        )
+        self._create_test_tim_file(
+            "file2.tim", f"FORMAT 1\n{_tempo2_line(55093.1109722889085)}\n"
+        )
         main_file = self._create_test_tim_file("main_multi.tim", main_content)
-        self._create_test_tim_file("file1.tim", file1_content)
-        self._create_test_tim_file("file2.tim", file2_content)
 
-        timespan = self.analyzer.calculate_timespan(main_file)
-
-        # Should include TOAs from all files: 55093.1109722889085 - 55087.1109722889085 = 6.0 days
-        assert timespan == 6.0
+        meta = self.analyzer.get_tim_metadata(main_file)
+        assert meta.toa_count == 3
+        assert meta.timespan_days == pytest.approx(6.0)
 
     def test_include_missing_file(self):
-        """Test handling of missing INCLUDE file."""
-        main_content = f"""FORMAT 1
-INCLUDE missing.tim
-{self._create_tempo2_line(55087.1109722889085)}
-"""
+        main_content = (
+            f"FORMAT 1\nINCLUDE missing.tim\n{_tempo2_line(55087.1109722889085)}\n"
+        )
         main_file = self._create_test_tim_file("main_missing.tim", main_content)
+        meta = self.analyzer.get_tim_metadata(main_file)
 
-        timespan = self.analyzer.calculate_timespan(main_file)
-
-        # Should only include TOAs from main file: 0.0 days (single TOA)
-        assert timespan == 0.0
+        assert meta.toa_count == 1
+        assert meta.timespan_days == 0.0
+        assert any("not found" in w for w in meta.parse_warnings)
 
     def test_include_circular_reference(self):
-        """Test handling of circular INCLUDE references."""
-        # File A includes B, B includes A - should detect and prevent infinite loop
-        file_a_content = f"""FORMAT 1
-INCLUDE file_b.tim
-{self._create_tempo2_line(55087.1109722889085)}
-"""
-        file_b_content = f"""FORMAT 1
-INCLUDE file_a.tim
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-
+        file_a_content = (
+            f"FORMAT 1\nINCLUDE file_b.tim\n{_tempo2_line(55087.1109722889085)}\n"
+        )
+        file_b_content = (
+            f"FORMAT 1\nINCLUDE file_a.tim\n{_tempo2_line(55090.1109722889085)}\n"
+        )
         file_a = self._create_test_tim_file("file_a.tim", file_a_content)
         self._create_test_tim_file("file_b.tim", file_b_content)
 
-        timespan = self.analyzer.calculate_timespan(file_a)
+        meta = self.analyzer.get_tim_metadata(file_a)
+        assert meta.toa_count >= 1
+        assert meta.timespan_days >= 0.0
+        assert any("Circular INCLUDE" in w for w in meta.parse_warnings)
 
-        # Should handle circular reference gracefully and not crash
-        assert timespan >= 0.0
+    def test_include_same_file_twice(self):
+        """Repeated INCLUDE of the same file counts TOAs each time."""
+        chunk_content = f"FORMAT 1\n{_tempo2_line(55090.1109722889085)}\n"
+        self._create_test_tim_file("chunk.tim", chunk_content)
+        main_content = f"""FORMAT 1
+INCLUDE chunk.tim
+{_tempo2_line(55087.1109722889085)}
+INCLUDE chunk.tim
+"""
+        main_file = self._create_test_tim_file("repeat_include.tim", main_content)
+        meta = self.analyzer.get_tim_metadata(main_file)
+
+        assert meta.toa_count == 3
+        assert meta.timespan_days == pytest.approx(3.0)
+        assert not any("Circular INCLUDE" in w for w in meta.parse_warnings)
 
     def test_include_nested(self):
-        """Test nested INCLUDE statements."""
-        # File A includes B, B includes C - should process all levels
-        file_a_content = f"""FORMAT 1
-INCLUDE file_b_nested.tim
-{self._create_tempo2_line(55087.1109722889085)}
-"""
-        file_b_content = f"""FORMAT 1
-INCLUDE file_c_nested.tim
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        file_c_content = f"""FORMAT 1
-{self._create_tempo2_line(55093.1109722889085)}
-"""
-
+        file_a_content = f"FORMAT 1\nINCLUDE file_b_nested.tim\n{_tempo2_line(55087.1109722889085)}\n"
+        file_b_content = f"FORMAT 1\nINCLUDE file_c_nested.tim\n{_tempo2_line(55090.1109722889085)}\n"
+        file_c_content = f"FORMAT 1\n{_tempo2_line(55093.1109722889085)}\n"
         file_a = self._create_test_tim_file("file_a_nested.tim", file_a_content)
         self._create_test_tim_file("file_b_nested.tim", file_b_content)
         self._create_test_tim_file("file_c_nested.tim", file_c_content)
 
-        timespan = self.analyzer.calculate_timespan(file_a)
+        meta = self.analyzer.get_tim_metadata(file_a)
+        assert meta.toa_count == 3
+        assert meta.timespan_days == pytest.approx(6.0)
 
-        # Should include TOAs from all nested files: 55093.1109722889085 - 55087.1109722889085 = 6.0 days
-        assert timespan == 6.0
+    def test_format_inheritance_in_include(self):
+        """Included file without FORMAT inherits parent FORMAT 1 state."""
+        main_content = f"FORMAT 1\nINCLUDE child.tim\n{_tempo2_line(58000.0)}\n"
+        child_content = f"{_tempo2_line(58001.0)}\n"
+        main_file = self._create_test_tim_file("inherit_main.tim", main_content)
+        self._create_test_tim_file("child.tim", child_content)
 
-    # Command Handling Tests
+        meta = self.analyzer.get_tim_metadata(main_file)
+        assert meta.toa_count == 2
 
-    def test_handle_format_command(self):
-        """Test FORMAT command handling."""
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("format_command.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # FORMAT command should be ignored, timespan should be calculated from TOAs
-        assert timespan == 3.0
-
-    def test_handle_jump_command(self):
-        """Test JUMP command handling."""
+    def test_directives_skipped(self):
         content = f"""FORMAT 1
 JUMP 55000 55001
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("jump_command.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # JUMP command should be ignored, timespan should be calculated from TOAs
-        assert timespan == 3.0
-
-    def test_handle_time_command(self):
-        """Test TIME command handling."""
-        content = f"""FORMAT 1
 TIME 55000
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
+T2EFAC -sys foo 1.0
+TNEQUAD -sys bar 2.0
+{_tempo2_line(55087.1109722889085)}
+{_tempo2_line(55090.1109722889085)}
 """
-        tim_file = self._create_test_tim_file("time_command.tim", content)
+        tim_file = self._create_test_tim_file("directives.tim", content)
+        meta = self.analyzer.get_tim_metadata(tim_file)
+        assert meta.toa_count == 2
+        assert meta.timespan_days == pytest.approx(3.0)
 
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # TIME command should be ignored, timespan should be calculated from TOAs
-        assert timespan == 3.0
-
-    def test_handle_phase_command(self):
-        """Test PHASE command handling."""
+    def test_malformed_lines_skipped(self):
         content = f"""FORMAT 1
-PHASE 0
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("phase_command.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # PHASE command should be ignored, timespan should be calculated from TOAs
-        assert timespan == 3.0
-
-    def test_handle_skip_commands(self):
-        """Test SKIP/NOSKIP command handling."""
-        content = f"""FORMAT 1
-SKIP
-{self._create_tempo2_line(55087.1109722889085)}
-NOSKIP
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("skip_commands.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # PINT correctly handles SKIP/NOSKIP commands - only non-skipped TOAs are processed
-        # Both TOAs are processed (SKIP/NOSKIP commands are handled by PINT internally)
-        assert timespan == 3.0  # Two TOAs with 3-day span
-
-    def test_handle_unknown_command(self):
-        """Test handling of unknown commands."""
-        content = f"""FORMAT 1
-UNKNOWN_COMMAND arg1 arg2
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("unknown_command.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # Unknown commands are gracefully skipped, valid TOAs are still processed
-        # This is more robust behavior than rejecting the entire file
-        assert timespan == 3.0  # Two valid TOAs with 3-day span
-
-    # Edge Cases and Error Handling Tests
-
-    def test_corrupted_file(self):
-        """Test handling of corrupted TIM file."""
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-corrupted line that should be ignored
-{self._create_tempo2_line(55090.1109722889085)}
+{_tempo2_line(55087.1109722889085)}
+corrupted line
+{_tempo2_line(55090.1109722889085)}
 """
         tim_file = self._create_test_tim_file("corrupted.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # Corrupted lines are gracefully skipped, valid TOAs are still processed
-        # This is more robust behavior than rejecting the entire file
-        assert timespan == 3.0  # Two valid TOAs with 3-day span
-
-    def test_mixed_formats(self):
-        """Test file with mixed TOA formats."""
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-1234567890abcdefghijklmnopqrstuvwxyz@ 1345.999 55090.1109722889085 2.890 g
-{self._create_tempo2_line(55093.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("mixed_formats.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # Should handle mixed formats correctly
-        assert timespan == 6.0
-
-    def test_unicode_characters(self):
-        """Test handling of Unicode characters in file."""
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-# Comment with unicode: αβγδε
-"""
-        tim_file = self._create_test_tim_file("unicode.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # Should handle Unicode characters gracefully
-        assert timespan == 3.0
+        meta = self.analyzer.get_tim_metadata(tim_file)
+        assert meta.toa_count == 2
+        assert meta.lines_skipped >= 1
 
     def test_comments_only(self):
-        """Test file with only comments and commands."""
         content = """FORMAT 1
-# This is a comment
-C This is another comment
+# comment
+C another comment
 JUMP 55000 55001
-TIME 55000
 """
         tim_file = self._create_test_tim_file("comments_only.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # Should return 0.0 for file with no TOAs
-        assert timespan == 0.0
-
-    def test_blank_lines_only(self):
-        """Test file with only blank lines."""
-        content = """
-
-
-"""
-        tim_file = self._create_test_tim_file("blank_only.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # Should return 0.0 for file with no TOAs
-        assert timespan == 0.0
-
-    # Caching Functionality Tests
+        meta = self.analyzer.get_tim_metadata(tim_file)
+        assert meta.toa_count == 0
 
     def test_cache_hit_behavior(self):
-        """Test that cache is used on subsequent calls to same file."""
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-"""
+        content = f"FORMAT 1\n{_tempo2_line(55087.1109722889085)}\n{_tempo2_line(55090.1109722889085)}\n"
         tim_file = self._create_test_tim_file("cache_test.tim", content)
 
-        # First call - should parse file and cache result
-        timespan1 = self.analyzer.calculate_timespan(tim_file)
-        assert timespan1 == 3.0
+        meta1 = self.analyzer.get_tim_metadata(tim_file)
+        assert tim_file.resolve() in self.analyzer._file_cache
 
-        # Verify file is in cache
-        assert tim_file in self.analyzer._file_cache
-        cached_timespan, cached_count = self.analyzer._file_cache[tim_file]
-        assert cached_timespan == 3.0
-        assert cached_count == 2
-
-        # Second call - should use cache (no file parsing)
-        timespan2 = self.analyzer.calculate_timespan(tim_file)
-        assert timespan2 == 3.0
-        assert timespan1 == timespan2
-
-    def test_cache_miss_behavior(self):
-        """Test that cache miss triggers file parsing."""
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("cache_miss_test.tim", content)
-
-        # Verify file is not in cache initially
-        assert tim_file not in self.analyzer._file_cache
-
-        # First call - should parse file and cache result
-        timespan = self.analyzer.calculate_timespan(tim_file)
-        assert timespan == 3.0
-
-        # Verify file is now in cache
-        assert tim_file in self.analyzer._file_cache
-
-    def test_cache_with_multiple_files(self):
-        """Test caching behavior with multiple different files."""
-        # Create multiple files with different content
-        file1_content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        file2_content = f"""FORMAT 1
-{self._create_tempo2_line(55093.1109722889085)}
-{self._create_tempo2_line(55096.1109722889085)}
-{self._create_tempo2_line(55099.1109722889085)}
-"""
-        file3_content = f"""FORMAT 1
-{self._create_tempo2_line(55100.1109722889085)}
-"""
-
-        file1 = self._create_test_tim_file("cache_multi1.tim", file1_content)
-        file2 = self._create_test_tim_file("cache_multi2.tim", file2_content)
-        file3 = self._create_test_tim_file("cache_multi3.tim", file3_content)
-
-        # Parse all files
-        timespan1 = self.analyzer.calculate_timespan(file1)
-        timespan2 = self.analyzer.calculate_timespan(file2)
-        timespan3 = self.analyzer.calculate_timespan(file3)
-
-        assert timespan1 == 3.0
-        assert timespan2 == 6.0
-        assert timespan3 == 0.0
-
-        # Verify all files are cached
-        assert file1 in self.analyzer._file_cache
-        assert file2 in self.analyzer._file_cache
-        assert file3 in self.analyzer._file_cache
-
-        # Verify cache contains correct data for each file
-        assert self.analyzer._file_cache[file1] == (3.0, 2)
-        assert self.analyzer._file_cache[file2] == (6.0, 3)
-        assert self.analyzer._file_cache[file3] == (0.0, 1)
-
-        # Verify cache hit on subsequent calls
-        assert self.analyzer.calculate_timespan(file1) == 3.0
-        assert self.analyzer.calculate_timespan(file2) == 6.0
-        assert self.analyzer.calculate_timespan(file3) == 0.0
+        meta2 = self.analyzer.get_tim_metadata(tim_file)
+        assert meta1 == meta2
 
     def test_cache_clear_functionality(self):
-        """Test that clear_cache() removes all cached data."""
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("cache_clear_test.tim", content)
+        content = f"FORMAT 1\n{_tempo2_line(55087.1109722889085)}\n"
+        tim_file = self._create_test_tim_file("cache_clear.tim", content)
+        self.analyzer.get_tim_metadata(tim_file)
+        assert tim_file.resolve() in self.analyzer._file_cache
 
-        # Parse file and verify it's cached
-        timespan = self.analyzer.calculate_timespan(tim_file)
-        assert timespan == 3.0
-        assert tim_file in self.analyzer._file_cache
-
-        # Clear cache
         self.analyzer.clear_cache()
-
-        # Verify cache is empty
         assert len(self.analyzer._file_cache) == 0
-        assert tim_file not in self.analyzer._file_cache
 
-        # Verify file can still be parsed after cache clear
-        timespan_after_clear = self.analyzer.calculate_timespan(tim_file)
-        assert timespan_after_clear == 3.0
-        assert tim_file in self.analyzer._file_cache  # Should be cached again
+        meta = self.analyzer.get_tim_metadata(tim_file)
+        assert meta.toa_count == 1
 
-    def test_cache_with_failed_parsing(self):
-        """Test that failed parsing results are also cached."""
-        # Create a file that will cause parsing to fail
-        corrupted_content = """FORMAT 1
-completely invalid line that will cause parsing failure
-another invalid line
-"""
-        tim_file = self._create_test_tim_file("cache_fail_test.tim", corrupted_content)
-
-        # First call should fail and cache empty result
-        timespan1 = self.analyzer.calculate_timespan(tim_file)
-        assert timespan1 == 0.0
-
-        # Verify failed result is cached
-        assert tim_file in self.analyzer._file_cache
-        cached_timespan, cached_count = self.analyzer._file_cache[tim_file]
-        assert cached_timespan == 0.0
-        assert cached_count == 0
-
-        # Second call should use cached empty result
-        timespan2 = self.analyzer.calculate_timespan(tim_file)
-        assert timespan2 == 0.0
-        assert timespan1 == timespan2
-
-    def test_cache_with_empty_file(self):
-        """Test caching behavior with empty files."""
-        empty_file = self._create_test_tim_file("cache_empty_test.tim", "")
-
-        # Parse empty file
-        timespan = self.analyzer.calculate_timespan(empty_file)
-        assert timespan == 0.0
-
-        # Verify empty result is cached
-        assert empty_file in self.analyzer._file_cache
-        cached_timespan, cached_count = self.analyzer._file_cache[empty_file]
-        assert cached_timespan == 0.0
-        assert cached_count == 0
-
-        # Verify cache hit on subsequent calls
-        assert self.analyzer.calculate_timespan(empty_file) == 0.0
-
-    def test_cache_with_missing_file(self):
-        """Test caching behavior with missing files."""
-        missing_file = self.test_data_dir / "cache_missing_test.tim"
-
-        # Parse missing file
-        timespan = self.analyzer.calculate_timespan(missing_file)
-        assert timespan == 0.0
-
-        # Verify missing file result is cached
-        assert missing_file in self.analyzer._file_cache
-        cached_timespan, cached_count = self.analyzer._file_cache[missing_file]
-        assert cached_timespan == 0.0
-        assert cached_count == 0
-
-    def test_get_timespan_and_count_caching(self):
-        """Test that get_timespan_and_count uses the same cache as calculate_timespan."""
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-{self._create_tempo2_line(55093.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("cache_combined_test.tim", content)
-
-        # First call with calculate_timespan
-        timespan1 = self.analyzer.calculate_timespan(tim_file)
-        assert timespan1 == 6.0
-
-        # Verify file is cached
-        assert tim_file in self.analyzer._file_cache
-
-        # Call get_timespan_and_count - should use cache
-        timespan2, count = self.analyzer.get_timespan_and_count(tim_file)
-        assert timespan2 == 6.0
-        assert count == 3
-
-        # Verify cache still contains same data
-        cached_timespan, cached_count = self.analyzer._file_cache[tim_file]
-        assert cached_timespan == 6.0
-        assert cached_count == 3
-
-    def test_count_toas_caching(self):
-        """Test that count_toas uses the same cache as other methods."""
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("cache_count_test.tim", content)
-
-        # First call with calculate_timespan
-        timespan = self.analyzer.calculate_timespan(tim_file)
-        assert timespan == 3.0
-
-        # Verify file is cached
-        assert tim_file in self.analyzer._file_cache
-
-        # Call count_toas - should use cache
-        count = self.analyzer.count_toas(tim_file)
-        assert count == 2
-
-        # Verify cache still contains same data
-        cached_timespan, cached_count = self.analyzer._file_cache[tim_file]
-        assert cached_timespan == 3.0
-        assert cached_count == 2
-
-    def test_cache_persistence_across_method_calls(self):
-        """Test that cache persists across different method calls on same file."""
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-{self._create_tempo2_line(55093.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("cache_persistence_test.tim", content)
-
-        # Call different methods in sequence
-        timespan1 = self.analyzer.calculate_timespan(tim_file)
-        count1 = self.analyzer.count_toas(tim_file)
-        timespan2, count2 = self.analyzer.get_timespan_and_count(tim_file)
-        timespan3 = self.analyzer.calculate_timespan(tim_file)
-
-        # All should return consistent results
-        assert timespan1 == 6.0
-        assert count1 == 3
-        assert timespan2 == 6.0
-        assert count2 == 3
-        assert timespan3 == 6.0
-
-        # Cache should contain the data
-        assert tim_file in self.analyzer._file_cache
-        cached_timespan, cached_count = self.analyzer._file_cache[tim_file]
-        assert cached_timespan == 6.0
-        assert cached_count == 3
-
-    # Integration Tests
-
-    def test_integration_with_file_discovery(self):
-        """Test TimFileAnalyzer integration with FileDiscoveryService."""
-        # This test would require FileDiscoveryService, so we'll test the method directly
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("integration_test.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # Should calculate timespan correctly
-        assert timespan == 3.0
-
-    def test_timespan_in_enriched_data(self):
-        """Test that timespan appears correctly in enriched file data."""
-        # This test would require FileDiscoveryService, so we'll test the method directly
-        content = f"""FORMAT 1
-{self._create_tempo2_line(55087.1109722889085)}
-{self._create_tempo2_line(55090.1109722889085)}
-"""
-        tim_file = self._create_test_tim_file("enriched_data_test.tim", content)
-
-        timespan = self.analyzer.calculate_timespan(tim_file)
-
-        # Should calculate timespan correctly for enriched data
-        assert timespan == 3.0
+    def test_metadata_is_frozen(self):
+        content = f"FORMAT 1\n{_tempo2_line(58000.0)}\n"
+        tim_file = self._create_test_tim_file("frozen.tim", content)
+        meta = self.analyzer.get_tim_metadata(tim_file)
+        assert isinstance(meta, TimMetadata)
+        with pytest.raises(AttributeError):
+            meta.toa_count = 99  # type: ignore[misc]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Replaces the boolean `use_pulse_numbers` flag with an explicit string API (`"no"`, `"yes"`, `"reuse"`, `"overwrite"`) and centralizes pulse-number handling so consistent PTA merging can preserve phase coherence when per-PTA par models are forced onto a shared astrophysical template.

Pulse numbers are derived from each PTA’s **original** coherent `par` + `tim`, while pulsar objects are still loaded with the **merged** consistent par files. PINT and Tempo2 both get `TRACK -2` when tracking is enabled; Tempo2-derived pn-tim files are sanitized and Tempo2 par wrapping no longer breaks on `N`/`Y` fit flags.

## Problem

`create_metapulsar(..., combination_strategy="consistent")` rewrites par files across PTAs (e.g. drops DMX, aligns DM derivatives). That can destroy per-PTA phase coherence even when each input dataset was individually well timed. Without pulse-number tracking, a merged linear fit can land in the wrong rotational branch (phase-wrap-scale residuals).

Synthetic regression fixtures in `tests/fixtures/pulse_tracking/` (already on `main`) document this scenario: individually coherent `epta_like` + `nanograv_like` sets become incoherent after merge unless pulse numbers are applied.

## Changes

### API (`use_pulse_numbers: str = "yes"`)

| Mode | Behavior |
|------|----------|
| `"no"` | Ignore pulse numbers; no `TRACK -2` override (Tempo2). |
| `"yes"` | Reuse complete `-pn` on all TOAs; otherwise re-derive from original `par` + `tim`; warn on mixed partial `-pn`. |
| `"reuse"` | Same as `"yes"` when complete; warn and re-derive when `-pn` is missing or incomplete. |
| `"overwrite"` | Always re-derive `-pn` from original `par` + `tim`. |

- Booleans are rejected at factory entry with `ValueError`.
- Migration: `True` → `"yes"`, `False` → `"no"`.

### Implementation (`pint_helpers.py`)

- `validate_pulse_number_mode`, `classify_tim_pulse_numbers`, `_should_derive_pulse_numbers`
- `resolved_tim_for_pulse_numbers` — single entry point for tim path selection (original vs temp pn-tim)
- `sanitize_tempo2_tim_noise_directives` — strips `T2E*` / `TNE*` from Tempo2 `add_pulseNumber` output
- `par_text_with_track_minus_2` — line-based `TRACK -2` injection (fixes Tempo2 par re-serialization failures)
- `ensure_pint_track_minus_2` — sets PINT `TRACK -2`; warns if `TRACK` is absent

### Factory (`metapulsar_factory.py`)

- `_create_pulsar_objects` uses `resolved_tim_for_pulse_numbers` for both PINT and Tempo2 backends
- Derivation always uses `file_data[pta]["par_content"]` + original `.tim`; load uses consistent `file_pairs` par

### Tests & docs

- **New** `tests/test_pulse_number_helpers.py` — mode validation, classify/sanitize, reuse-with-complete-`-pn`, warnings, TRACK handling
- **`tests/test_pulse_tracking.py`** — `@pytest.mark.slow`; parametrized PINT + Tempo2 post-fit regression
- **`tests/test_metapulsar_factory.py`** — Tempo2 `TRACK -2` wiring, bool rejection
- Integration tests updated to `"yes"` / `"no"`
- **`README.md`** — pulse-number tracking section

## Breaking change

`use_pulse_numbers` must be a string. Update call sites:

```python
# before
create_metapulsar(file_data, use_pulse_numbers=True)
create_metapulsar(file_data, use_pulse_numbers=False)

# after
create_metapulsar(file_data, use_pulse_numbers="yes")
create_metapulsar(file_data, use_pulse_numbers="no")
```

## Test plan

- [x] `make fast` (pulse tracking slow tests deselected; helper tests stay on fast path)
- [x] `pytest tests/test_pulse_number_helpers.py -q`
- [x] `pytest tests/test_pulse_tracking.py -q` (slow; needs PINT + libstempo/Tempo2 for Tempo2 param)
- [x] `pytest tests/test_metapulsar_factory.py -k "pulse_numbers or create_pulsar_objects" -q`
- [x] Optional: `pytest tests/integration/test_legacy_comparison.py -k pulse_number_mode_residual_equivalence` (slow; IPTA data; expects `yes` ≈ `no` when merge does not break coherence — unlike synthetic regression)