### PR TITLE
Fix EDOT/ECCDOT alias resolution

### DIFF
--- a/src/metapulsar/metapulsar.py
+++ b/src/metapulsar/metapulsar.py
@@ -474,7 +474,11 @@ class MetaPulsar(ep.BasePulsar):
                         full_parname
                     ].items():
                         if mapped_pta == pta:
-                            par_idx = psr.fitpars_canonical.index(mapped_param)
+                            from .pint_helpers import resolve_parameter_alias
+
+                            par_idx = psr.fitpars_canonical.index(
+                                resolve_parameter_alias(mapped_param)
+                            )
                             column[slice_obj] = dm[:, par_idx]
                             break
 

--- a/src/metapulsar/pint_helpers.py
+++ b/src/metapulsar/pint_helpers.py
@@ -79,9 +79,9 @@ def resolve_parameter_alias(param_name: str) -> str:
     Returns:
         Canonical parameter name, or original name if not an alias
     """
-    # Handle special case: EDOT -> ECCDOT alias that PINT doesn't have
-    if param_name == "EDOT":
-        return "ECCDOT"
+    # Tempo2 uses ECCDOT; PINT canonical name is EDOT (not in AllComponents map).
+    if param_name == "ECCDOT":
+        return "EDOT"
 
     try:
         all_components = _get_all_components()
@@ -111,9 +111,9 @@ def get_aliases_for_parameter(canonical_param: str) -> List[str]:
             if canonical == canonical_param and alias != canonical_param:
                 aliases.append(alias)
 
-        # Handle special case: if canonical is ECCDOT, also include EDOT
-        if canonical_param == "ECCDOT" and "EDOT" not in aliases:
-            aliases.append("EDOT")
+        # Tempo2-style alias for eccentricity derivative (PINT canonical is EDOT).
+        if canonical_param == "EDOT" and "ECCDOT" not in aliases:
+            aliases.append("ECCDOT")
 
         return aliases
     except Exception:

--- a/src/metapulsar/pint_helpers.py
+++ b/src/metapulsar/pint_helpers.py
@@ -121,6 +121,65 @@ def get_aliases_for_parameter(canonical_param: str) -> List[str]:
         return [canonical_param]
 
 
+def _parfile_alias_value_present(parfile_dict: Dict[str, Any], alias: str) -> bool:
+    """Return True if alias is present in a parfile dict with a non-empty value."""
+    if alias not in parfile_dict:
+        return False
+    value = parfile_dict[alias]
+    if value is None:
+        return False
+    if isinstance(value, list):
+        if not value:
+            return False
+        return bool(str(value[0]).strip())
+    return bool(str(value).strip())
+
+
+def has_parameter_alias(parfile_dict: Dict[str, Any], canonical_param: str) -> bool:
+    """Return True if any PINT alias for canonical_param is present and non-empty."""
+    return any(
+        _parfile_alias_value_present(parfile_dict, alias)
+        for alias in get_aliases_for_parameter(canonical_param)
+    )
+
+
+def has_equatorial_astrometry(parfile_dict: Dict[str, Any]) -> bool:
+    """Return True if equatorial astrometry parameters are present (via PINT aliases)."""
+    return has_parameter_alias(parfile_dict, "RAJ") and has_parameter_alias(
+        parfile_dict, "DECJ"
+    )
+
+
+def has_ecliptic_astrometry(parfile_dict: Dict[str, Any]) -> bool:
+    """Return True if ecliptic astrometry parameters are present (via PINT aliases)."""
+    return has_parameter_alias(parfile_dict, "ELONG") and has_parameter_alias(
+        parfile_dict, "ELAT"
+    )
+
+
+def detect_astrometry_style(parfile_dict: Dict[str, Any]) -> str:
+    """Detect whether a parfile uses equatorial or ecliptic astrometry.
+
+    Uses PINT's alias map rather than hard-coded parameter names.
+    """
+    has_equatorial = has_equatorial_astrometry(parfile_dict)
+    has_ecliptic = has_ecliptic_astrometry(parfile_dict)
+
+    if has_equatorial and has_ecliptic:
+        raise ValueError(
+            "Mixed astrometry detected (equatorial and ecliptic parameters present). "
+            "Refuse to make ambiguous coordinate representation consistent."
+        )
+    if has_ecliptic:
+        return "ecliptic"
+    if has_equatorial:
+        return "equatorial"
+    raise ValueError(
+        "Could not detect astrometry style. Expected either RAJ/DECJ or "
+        "LAMBDA/BETA (or ELONG/ELAT)."
+    )
+
+
 def clear_all_components_cache():
     """Clear the AllComponents cache.
 

--- a/tests/test_metapulsar_design_matrix.py
+++ b/tests/test_metapulsar_design_matrix.py
@@ -5,6 +5,7 @@ import pytest
 
 from metapulsar.metapulsar import MetaPulsar
 from metapulsar.mockpulsar import create_mock_libstempo
+from metapulsar.pint_helpers import resolve_parameter_alias
 
 
 class TestMetaPulsarDesignMatrix:
@@ -168,3 +169,17 @@ class TestMetaPulsarDesignMatrix:
         dm_consistent = self.consistent_mp._designmatrix
         assert dm_composite.shape[0] == 60
         assert dm_consistent.shape[0] == 60
+
+    def test_design_matrix_edot_parameter_index_lookup(self):
+        """EDOT fitpars must align with fitpars_canonical for column construction."""
+        fitpars = ["EDOT", "F0", "RAJ"]
+        fitpars_canonical = [resolve_parameter_alias(p) for p in fitpars]
+        mapped_param = "EDOT"
+
+        par_idx = fitpars_canonical.index(resolve_parameter_alias(mapped_param))
+        assert par_idx == 0
+        assert fitpars_canonical[par_idx] == "EDOT"
+
+        mapped_param = "ECCDOT"
+        par_idx = fitpars_canonical.index(resolve_parameter_alias(mapped_param))
+        assert par_idx == 0

--- a/tests/test_pint_helpers.py
+++ b/tests/test_pint_helpers.py
@@ -2,11 +2,15 @@
 
 import pytest
 from unittest.mock import Mock, patch
+from pint.models.timing_model import AllComponents
+
 from metapulsar.pint_helpers import (
     check_component_available_in_model,
+    get_aliases_for_parameter,
     get_parameter_identifiability_from_model,
     get_parameters_by_type_from_parfiles,
     create_pint_model,
+    resolve_parameter_alias,
     PINTDiscoveryError,
 )
 
@@ -44,6 +48,43 @@ def mock_astrometry_components():
     mock_instance.AstrometryEcliptic = mock_astrometry_ec
 
     return mock_instance
+
+
+class TestResolveParameterAlias:
+    """Test resolve_parameter_alias and get_aliases_for_parameter."""
+
+    def test_edot_matches_pint_canonical(self):
+        """EDOT should stay EDOT to match PINT AllComponents."""
+        pint_canon, _ = AllComponents().alias_to_pint_param("EDOT")
+        assert resolve_parameter_alias("EDOT") == pint_canon == "EDOT"
+
+    def test_eccdot_maps_to_edot(self):
+        """Tempo2-style ECCDOT should resolve to PINT canonical EDOT."""
+        assert resolve_parameter_alias("ECCDOT") == "EDOT"
+
+    def test_edot_aliases_include_eccdot(self):
+        """EDOT canonical name should list Tempo2-style ECCDOT alias."""
+        aliases = get_aliases_for_parameter("EDOT")
+        assert "EDOT" in aliases
+        assert "ECCDOT" in aliases
+
+    def test_fitpars_canonical_index_lookup_with_edot(self):
+        """Mapped EDOT must be found in fitpars_canonical for design-matrix indexing."""
+        fitpars = ["EDOT", "F0", "RAJ"]
+        fitpars_canonical = [resolve_parameter_alias(p) for p in fitpars]
+        mapped_param = "EDOT"
+
+        assert fitpars_canonical == ["EDOT", "F0", "RAJ"]
+        assert fitpars_canonical.index(mapped_param) == 0
+
+    def test_fitpars_canonical_index_lookup_with_eccdot(self):
+        """Enterprise fitpars with Tempo2 ECCDOT name must still index correctly."""
+        fitpars = ["ECCDOT", "F0", "RAJ"]
+        fitpars_canonical = [resolve_parameter_alias(p) for p in fitpars]
+        mapped_param = "ECCDOT"
+
+        assert fitpars_canonical == ["EDOT", "F0", "RAJ"]
+        assert fitpars_canonical.index(resolve_parameter_alias(mapped_param)) == 0
 
 
 # These tests are commented out until the function is implemented as part of the refactor

--- a/tests/test_pint_helpers.py
+++ b/tests/test_pint_helpers.py
@@ -665,3 +665,45 @@ T0 55000.0 1
             # Should still call ModelBuilder
             mock_builder.assert_called_once()
             assert result == mock_model
+
+
+class TestAstrometryStyleHelpers:
+    """Test alias-driven astrometry style detection helpers."""
+
+    def test_has_parameter_alias_accepts_pint_aliases(self):
+        from metapulsar.pint_helpers import has_parameter_alias
+
+        parfile_dict = {"LAMBDA": ["244.347"], "BETA": ["-10.07"]}
+        assert has_parameter_alias(parfile_dict, "ELONG")
+        assert has_parameter_alias(parfile_dict, "ELAT")
+        assert not has_parameter_alias(parfile_dict, "RAJ")
+
+    def test_detect_astrometry_style_equatorial_aliases(self):
+        from metapulsar.pint_helpers import detect_astrometry_style
+
+        parfile_dict = {
+            "RA": ["18:57:36.3937"],
+            "DEC": ["+09:43:17.291"],
+        }
+        assert detect_astrometry_style(parfile_dict) == "equatorial"
+
+    def test_detect_astrometry_style_ecliptic_aliases(self):
+        from metapulsar.pint_helpers import detect_astrometry_style
+
+        parfile_dict = {
+            "ELONG": ["244.347"],
+            "ELAT": ["-10.07"],
+        }
+        assert detect_astrometry_style(parfile_dict) == "ecliptic"
+
+    def test_detect_astrometry_style_mixed_raises(self):
+        from metapulsar.pint_helpers import detect_astrometry_style
+
+        parfile_dict = {
+            "RAJ": ["18:57:36.3937"],
+            "DECJ": ["+09:43:17.291"],
+            "LAMBDA": ["244.347"],
+            "BETA": ["-10.07"],
+        }
+        with pytest.raises(ValueError, match="Mixed astrometry detected"):
+            detect_astrometry_style(parfile_dict)


### PR DESCRIPTION
## Summary

- Fixes a parameter alias bug where MetaPulsar mapped PINT’s canonical `EDOT` to Tempo2-style `ECCDOT`, breaking design-matrix column lookup.
- Cherry-picks the missing `detect_astrometry_style` helper (and related PINT alias utilities) so legacy comparison tests can import again after legacy code landed on `main`.

## Problem

MetaPulsar maintains three related naming layers for fit parameters:

1. **Full parameter name** — MetaPulsar-level key in `self.fitpars`
2. **`mapped_param`** — per-PTA native name from `_fitparameters`
3. **`fitpars_canonical`** — alias-resolved Enterprise index list

For eccentricity derivative, PINT’s canonical name is **`EDOT`**. MetaPulsar had a hard-coded override mapping `EDOT → ECCDOT` (legacy Tempo2 naming). That caused:

```python
fitpars           = ["EDOT", "F0", "RAJ"]
fitpars_canonical = ["ECCDOT", "F0", "RAJ"]   # after bad canonicalization
mapped_param      = "EDOT"

fitpars_canonical.index(mapped_param)  # ValueError
```

Separately, legacy code on `main` imports `detect_astrometry_style` from `pint_helpers`, but that function was never merged — causing 5 integration test collection errors.

## Changes

### 1. Fix EDOT/ECCDOT alias resolution (`pint_helpers.py`)
- Remove incorrect `EDOT → ECCDOT` override.
- Map Tempo2-style `ECCDOT → EDOT` (PINT does not register `ECCDOT` in `AllComponents`).
- Update `get_aliases_for_parameter("EDOT")` to include `ECCDOT` as an alias.

### 2. Fix design-matrix lookup (`metapulsar.py`)
- Canonicalize `mapped_param` before indexing `psr.fitpars_canonical`, so native and canonical names align consistently.

### 3. Restore astrometry style detection (`pint_helpers.py`, cherry-picked from `44b32578`)
Adds alias-driven helpers used by legacy code:
- `_parfile_alias_value_present`
- `has_parameter_alias`
- `has_equatorial_astrometry` / `has_ecliptic_astrometry`
- `detect_astrometry_style`

Note: only the `pint_helpers` + test portion of `44b32578` was taken; the `parameter_manager` convention-harmonization refactor from that branch was **not** included (not present on `main`).

## Test plan

- [x] `TestResolveParameterAlias` — EDOT stays EDOT, ECCDOT maps to EDOT, alias list includes both
- [x] `test_design_matrix_edot_parameter_index_lookup` — index lookup works for `EDOT` and `ECCDOT`
- [x] `TestAstrometryStyleHelpers` — equatorial/ecliptic detection and mixed-astrometry error
- [x] Legacy import: `from metapulsar.legacy import metapulsar` succeeds
- [x] Legacy comparison tests collect without import errors
- [x] Full `make test`

## Related context

This addresses the issue flagged when reviewing the distinction between `mapped_param`, `fitpars_canonical`, and full parameter names — specifically when `EDOT` appears in parfiles.