### PR TITLE
fix(selection): restore per-TOA staggered fallback in tuple criteria

### DIFF
--- a/src/metapulsar/selection_utils.py
+++ b/src/metapulsar/selection_utils.py
@@ -149,23 +149,54 @@ def create_staggered_selection(
                     result.update(selections)
 
             elif isinstance(flag_spec, tuple):
-                # Staggered flags - try each flag in order until one is available
-                flag_values = None
-
-                for flag_name in flag_spec:
-                    if flag_name in flags:
-                        flag_values = flags[flag_name]
-                        break
-
-                if flag_values is not None:
-                    selections = _create_selections_for_flag(
-                        flag_values, target_value, name, freq_mask
-                    )
-                    result.update(selections)
+                selections = _create_staggered_selections_for_flags(
+                    flags, flag_spec, target_value, name, freq_mask
+                )
+                result.update(selections)
 
         return result
 
     return selection_function
+
+
+def _create_staggered_selections_for_flags(
+    flags: Dict[str, np.ndarray],
+    flag_names: Tuple[str, ...],
+    target_value: Optional[str],
+    base_name: str,
+    freq_mask: np.ndarray,
+) -> Dict[str, np.ndarray]:
+    """Create staggered selections with per-TOA fallback across flag columns."""
+    n_toas = len(freq_mask)
+    for flag_name in flag_names:
+        if flag_name in flags:
+            n_toas = len(flags[flag_name])
+            break
+    else:
+        if not flags:
+            return {}
+        n_toas = len(next(iter(flags.values())))
+
+    msk_todo = np.ones(n_toas, dtype=bool)
+    selections: Dict[str, np.ndarray] = {}
+
+    for flag_name in flag_names:
+        if flag_name not in flags:
+            continue
+
+        flag_values = flags[flag_name]
+        if target_value is None:
+            values = set(flag_values) - {""}
+        else:
+            values = {target_value}
+
+        for value in values:
+            msk_flag = (flag_values == value) & freq_mask
+            if np.any(msk_todo & msk_flag):
+                selections[f"{base_name}_{value}"] = msk_flag
+                msk_todo &= ~msk_flag
+
+    return selections
 
 
 def _create_selections_for_flag(

--- a/tests/test_selections.py
+++ b/tests/test_selections.py
@@ -364,6 +364,32 @@ class TestStaggeredSelection:
         for key in expected:
             np.testing.assert_array_equal(result[key], expected[key])
 
+    def test_staggered_partial_primary_uses_fallback_per_toa(self):
+        """Test per-TOA fallback when primary flag exists but is empty on some TOAs."""
+        sel_func = create_staggered_selection("efeq", {("group", "f"): None})
+
+        flags = {
+            "group": np.array(["EPTA_BE", "", ""]),
+            "f": np.array(["", "NG_BE", "PPTA_BE"]),
+        }
+        freqs = np.array([100.0, 200.0, 300.0])
+
+        result = sel_func(flags, freqs)
+        expected = {
+            "efeq_EPTA_BE": np.array([True, False, False]),
+            "efeq_NG_BE": np.array([False, True, False]),
+            "efeq_PPTA_BE": np.array([False, False, True]),
+        }
+
+        assert set(result.keys()) == set(expected.keys())
+        for key in expected:
+            np.testing.assert_array_equal(result[key], expected[key])
+
+        combined = np.zeros(len(freqs), dtype=bool)
+        for mask in result.values():
+            combined |= mask
+        np.testing.assert_array_equal(combined, np.ones(len(freqs), dtype=bool))
+
     def test_staggered_no_flags_available(self):
         """Test staggered selection when no flags are available"""
         sel_func = create_staggered_selection("ecorr", {("missing1", "missing2"): None})


### PR DESCRIPTION
## Summary

- Fixes `create_staggered_selection` so tuple criteria (e.g. `{("group", "f"): None}`) use **per-TOA** fallback, matching legacy `create_selection_stag`.
- Previously, stagger picked the first flag column that existed anywhere in the dataset and applied it to all TOAs, leaving some rows uncovered when that column was empty on a subset of TOAs.
- Adds a regression test for the partial-primary / per-TOA fallback case that IPTA combined datasets hit.

## Problem

`create_staggered_selection` was documented and tested as a drop-in replacement for legacy staggered selection, but tuple handling differed in an important way:

| Behavior | Legacy `create_selection_stag` | Broken `create_staggered_selection` |
|----------|-------------------------------|-------------------------------------|
| Stagger semantics | Per TOA: try `group`, then assign remaining TOAs from `f`, etc. | Global: if `group` exists in `flags`, use only that column for everyone |
| IPTA impact | Full TOA coverage across PTAs | PPTA TOAs with empty `group` get no white-noise mask |

On combined IPTA DR2 data (e.g. `{("group", "f"): None}` for EFAC+EQUAD), this left **410 PPTA TOAs** with zero measurement noise variance

Existing tests only covered:
1. Both flags populated on every TOA (works in both implementations)
2. Primary flag column **entirely absent** from `flags` (works)

They did not cover the critical case: **flag column present but empty on some TOAs**.

## Solution

Introduce `_create_staggered_selections_for_flags()` with legacy-style `msk_todo` tracking:

1. Start with all TOAs unassigned.
2. Walk flag columns in tuple order.
3. For each backend value, add a mask only if some still-unassigned TOAs match.
4. Remove matched TOAs before trying the next flag.

Single-string criteria (`{"group": None}`) are unchanged.