### PR TITLE
Keep each PTA's reference `DM` separate, like FDJUMPDM by default (or exclude any other parameter)

### DIFF
--- a/docs/METHOD_DESCRIPTION.md
+++ b/docs/METHOD_DESCRIPTION.md
@@ -52,9 +52,11 @@ Concretely:
 To avoid PTA‑specific *DMX* implementations and make the deterministic part of the dispersion model uniform, MetaPulsar:
 
 * removes **DMX** parameters if present,
-* ensures that **DM** is present and marked **free**,
+* preserves each PTA's local **DM** reference value and marks it **free** (by default via `exclude_from_consistent=("DM",)`),
 * defines a fixed **DMEPOCH** (copied from the reference; frozen), and
 * optionally inserts **DM1** and **DM2** (default: present and **free**, initialized at 0).
+
+For dispersion, MetaPulsar removes DMX terms and keeps the Taylor DM evolution consistent, but `DM` itself is PTA-local by default. The `DM` value in a par file is the reference DM used when producing that PTA's TOAs, so the default `exclude_from_consistent=("DM",)` preserves those reference values while exposing `DM_<pta>` fit parameters in the combined design matrix.
 
 This choice keeps the deterministic dispersion expansion identical across PTAs while leaving the **stochastic DM process** (DM GP) to the noise model, as is standard practice.
 
@@ -131,7 +133,8 @@ MetaPulsar validates that all PTAs refer to the **same sky position** by convert
 
 MetaPulsar now defines the **meta‑parameters** that the combined design matrix will use.
 
-* For any parameter that belongs to a consistent component and exists across PTAs, MetaPulsar exposes **one merged meta‑parameter** (e.g., `RAJ`, `F0`, `PB`, `DM`), mapped to the corresponding parameter name in each PTA object.
+* For any parameter that belongs to a consistent component and exists across PTAs, MetaPulsar exposes **one merged meta‑parameter** (e.g., `RAJ`, `F0`, `PB`, `DM1`), mapped to the corresponding parameter name in each PTA object.
+* By default, `DM` is excluded from consistent merging (`exclude_from_consistent=("DM",)`) and is exposed as PTA-specific meta-parameters (`DM_<pta>`), because the par-file `DM` is each PTA's reference value for TOA production.
 * All **detector‑specific** timing‑model parameters (e.g., `JUMP`, `FD*`, per‑backend offsets) are exposed as **PTA‑specific** meta‑parameters by suffixing with the PTA label (e.g., `JUMP_XXXX_epta`, `Offset_nanograv`).
 * If a per‑dataset **phase offset** is implicit in a given timing package, MetaPulsar explicitly includes an **`Offset_<pta>`** meta‑parameter to reflect the standard constant phase term that is effectively fit in pulsar timing (this is not a noise parameter).
 * NOTE: The `Offset_XXXX` parameter is effectively just a `JUMP_XXXX` parameter for that specific PTA. But the name `Offset` makes it clear it is _not_ an added parameter, but merely the mapped phase offset from a specific PTA.
@@ -199,7 +202,7 @@ Any re‑timing that yields the **same column space** of ( **M** ) produces the 
 ### Minimal algorithm (for reference)
 
 1. **Parse & normalize units** for all PTAs (`UNITS → TDB` only when needed).
-2. **Make consistent** selected components by copying reference PTA values; **leave detector‑specific timing‑model parameters as PTA‑local**; for dispersion: remove DMX, set DM (free), set DMEPOCH (frozen), add DM1/DM2 (free, 0).
+2. **Make consistent** selected components by copying reference PTA values; **leave detector‑specific timing‑model parameters as PTA‑local**; for dispersion: remove DMX, preserve each PTA's local DM value and mark it free, set DMEPOCH (frozen), add DM1/DM2 (free, 0).
 3. **Apply consistent convention rules**: for single‑PTA pulsars, skip multi‑PTA alignment; for multi‑PTA pulsars, align `EPHEM`, `CLOCK/CLK`, then apply cross-engine rules only when both PINT and tempo2 are present, otherwise apply single-engine multi-PTA alignment only when conventions are heterogeneous.
 4. **Instantiate** Enterprise pulsars (PINT or Tempo2 path). Validate same pulsar by coordinates.
 5. **Map parameters** into merged and PTA‑specific meta‑parameters (deterministic mapping).

--- a/src/metapulsar/metapulsar.py
+++ b/src/metapulsar/metapulsar.py
@@ -43,6 +43,7 @@ class MetaPulsar(ep.BasePulsar):
             "dispersion",
         ],
         add_dm_derivatives: bool = True,
+        exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
         sort=True,
     ):
         """Create MetaPulsar from multiple PTA pulsars.
@@ -61,6 +62,11 @@ class MetaPulsar(ep.BasePulsar):
                 - "dispersion": Dispersion measure parameters
                 Defaults to all components
             add_dm_derivatives: Whether to ensure DM1, DM2 are present (consistent strategy only)
+            exclude_from_consistent: Canonical timing-model parameter names to keep
+                PTA-specific even when their component is in combine_components.
+                Defaults to ("DM",) so each PTA keeps its own reference DM while
+                consistent dispersion still shares DM1/DM2. Pass an empty list to
+                merge all parameters in selected components.
             sort: Whether to sort data by time
         """
         self._pulsars = pulsars
@@ -71,6 +77,7 @@ class MetaPulsar(ep.BasePulsar):
             combine_components if combination_strategy == "consistent" else []
         )
         self.add_dm_derivatives = add_dm_derivatives
+        self.exclude_from_consistent = exclude_from_consistent
         self._sort = sort  # BasePulsar handles sorting
 
         # Elegant initialization flow
@@ -259,6 +266,7 @@ class MetaPulsar(ep.BasePulsar):
             file_data=file_data,
             combine_components=combine_components,
             add_dm_derivatives=self.add_dm_derivatives,
+            exclude_from_consistent=self.exclude_from_consistent,
         )
 
         mapping = parameter_manager.build_parameter_mappings()

--- a/src/metapulsar/metapulsar.py
+++ b/src/metapulsar/metapulsar.py
@@ -1,5 +1,7 @@
 """Main MetaPulsar class for combining multi-PTA pulsar timing data."""
 
+from __future__ import annotations
+
 from itertools import groupby
 from typing import List
 import numpy as np

--- a/src/metapulsar/metapulsar_factory.py
+++ b/src/metapulsar/metapulsar_factory.py
@@ -4,6 +4,8 @@ This module provides a factory class that creates MetaPulsars by discovering fil
 creating Enterprise Pulsars, and wrapping them with metadata.
 """
 
+from __future__ import annotations
+
 from typing import Dict, List, Tuple, Any
 from pathlib import Path
 from loguru import logger

--- a/src/metapulsar/metapulsar_factory.py
+++ b/src/metapulsar/metapulsar_factory.py
@@ -144,6 +144,7 @@ class MetaPulsarFactory:
         reference_pta: str = None,
         combine_components: List[str] = DEFAULT_COMBINE_COMPONENTS,
         add_dm_derivatives: bool = True,
+        exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
         parfile_output_dir: Path = None,
         use_pulse_numbers: str = "yes",
     ) -> MetaPulsar:
@@ -158,6 +159,11 @@ class MetaPulsarFactory:
             combine_components: List of components to make consistent (for consistent strategy).
                 Defaults to all components: ["astrometry", "spindown", "binary", "dispersion"]
             add_dm_derivatives: Whether to ensure DM1, DM2 are present in all par files (for consistent strategy)
+            exclude_from_consistent: Canonical timing-model parameter names to keep
+                PTA-specific even when their component is in ``combine_components``.
+                Defaults to ``("DM",)`` so each PTA keeps its own reference DM while
+                consistent dispersion still shares ``DM1``/``DM2``. Pass an empty list to
+                merge all parameters in selected components.
             parfile_output_dir: Directory to save consistent par files (for consistent strategy only).
                 If None, par files are not saved to disk.
             use_pulse_numbers: Pulse-number mode (string only; default ``"yes"``):
@@ -229,6 +235,7 @@ class MetaPulsarFactory:
                 add_dm_derivatives=add_dm_derivatives,
                 output_dir=parfile_output_dir,
                 pulsar_name=pulsar_name,
+                exclude_from_consistent=exclude_from_consistent,
             )
 
             # Make par files consistent
@@ -258,6 +265,7 @@ class MetaPulsarFactory:
             combination_strategy=combination_strategy,
             combine_components=combine_components,
             add_dm_derivatives=add_dm_derivatives,
+            exclude_from_consistent=exclude_from_consistent,
         )
 
     def _validate_single_pulsar_data(
@@ -442,6 +450,7 @@ class MetaPulsarFactory:
         reference_pta: str = None,
         combine_components: List[str] = DEFAULT_COMBINE_COMPONENTS,
         add_dm_derivatives: bool = True,
+        exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
         parfile_output_dir: Path = None,
         use_pulse_numbers: str = "yes",
     ) -> Dict[str, MetaPulsar]:
@@ -453,6 +462,10 @@ class MetaPulsarFactory:
             reference_pta: PTA to use as reference for all pulsars. If None, auto-selects by timespan.
             combine_components: List of components to make consistent
             add_dm_derivatives: Whether to ensure DM1, DM2 are present
+            exclude_from_consistent: Canonical timing-model parameter names to keep
+                PTA-specific even when their component is in ``combine_components``.
+                Defaults to ``("DM",)``. Pass an empty list to merge all parameters
+                in selected components.
             parfile_output_dir: Directory to save consistent par files (for consistent strategy only).
                 If None, par files are not saved to disk. Creates subdirectories for each pulsar.
 
@@ -488,6 +501,7 @@ class MetaPulsarFactory:
                     reference_pta=reference_pta_for_pulsar,
                     combine_components=combine_components,
                     add_dm_derivatives=add_dm_derivatives,
+                    exclude_from_consistent=exclude_from_consistent,
                     parfile_output_dir=parfile_output_dir,
                     use_pulse_numbers=pulse_mode,
                 )
@@ -866,6 +880,7 @@ def create_metapulsar(
     reference_pta: str = None,
     combine_components: List[str] = DEFAULT_COMBINE_COMPONENTS,
     add_dm_derivatives: bool = True,
+    exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
     parfile_output_dir: Path = None,
     use_pulse_numbers: str = "yes",
 ) -> MetaPulsar:
@@ -880,6 +895,10 @@ def create_metapulsar(
         combine_components: List of components to make consistent (for consistent strategy).
             Defaults to all components: ["astrometry", "spindown", "binary", "dispersion"]
         add_dm_derivatives: Whether to ensure DM1, DM2 are present in all par files (for consistent strategy)
+        exclude_from_consistent: Canonical timing-model parameter names to keep
+            PTA-specific even when their component is in ``combine_components``.
+            Defaults to ``("DM",)``. Pass an empty list to merge all parameters
+            in selected components.
         parfile_output_dir: Directory to save consistent par files (for consistent strategy only).
             If None, par files are not saved to disk.
         use_pulse_numbers: Pulse-number mode: ``"no"``, ``"yes"`` (default), ``"reuse"``,
@@ -899,6 +918,7 @@ def create_metapulsar(
         reference_pta=reference_pta,
         combine_components=combine_components,
         add_dm_derivatives=add_dm_derivatives,
+        exclude_from_consistent=exclude_from_consistent,
         parfile_output_dir=parfile_output_dir,
         use_pulse_numbers=use_pulse_numbers,
     )
@@ -910,6 +930,7 @@ def create_all_metapulsars(
     reference_pta: str = None,
     combine_components: List[str] = DEFAULT_COMBINE_COMPONENTS,
     add_dm_derivatives: bool = True,
+    exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
     parfile_output_dir: Path = None,
     use_pulse_numbers: str = "yes",
 ) -> Dict[str, MetaPulsar]:
@@ -921,6 +942,10 @@ def create_all_metapulsars(
         reference_pta: PTA to use as reference for all pulsars. If None, auto-selects by timespan.
         combine_components: List of components to make consistent
         add_dm_derivatives: Whether to ensure DM1, DM2 are present
+        exclude_from_consistent: Canonical timing-model parameter names to keep
+            PTA-specific even when their component is in ``combine_components``.
+            Defaults to ``("DM",)``. Pass an empty list to merge all parameters
+            in selected components.
         parfile_output_dir: Directory to save consistent par files (for consistent strategy only).
             If None, par files are not saved to disk. Creates subdirectories for each pulsar.
         use_pulse_numbers: Pulse-number mode passed to each ``create_metapulsar`` call
@@ -936,6 +961,7 @@ def create_all_metapulsars(
         reference_pta=reference_pta,
         combine_components=combine_components,
         add_dm_derivatives=add_dm_derivatives,
+        exclude_from_consistent=exclude_from_consistent,
         parfile_output_dir=parfile_output_dir,
         use_pulse_numbers=use_pulse_numbers,
     )

--- a/src/metapulsar/parameter_manager.py
+++ b/src/metapulsar/parameter_manager.py
@@ -63,6 +63,7 @@ class ParameterManager:
         add_dm_derivatives: bool = True,
         output_dir: Path = None,
         pulsar_name: str = None,
+        exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
     ):
         """Initialize with file data and configuration.
 
@@ -72,12 +73,20 @@ class ParameterManager:
             add_dm_derivatives: Whether to add DM1, DM2 parameters
             output_dir: Directory for output files
             pulsar_name: Name of the pulsar (used for output filename generation)
+            exclude_from_consistent: Canonical timing-model parameter names to keep
+                PTA-specific even when their component is in combine_components.
+                Defaults to ("DM",) so each PTA keeps its own reference DM while
+                consistent dispersion still shares DM1/DM2. Pass an empty list to
+                merge all parameters in selected components.
         """
         self.file_data = file_data
         self.combine_components = combine_components
         self.add_dm_derivatives = add_dm_derivatives
         self.output_dir = output_dir
         self.pulsar_name = pulsar_name
+        self.exclude_from_consistent = self._normalize_excluded_consistent_parameters(
+            exclude_from_consistent
+        )
 
         # Use first dictionary key as reference (consistent with MetaPulsarFactory)
         self.reference_pta = next(iter(file_data.keys()))
@@ -104,6 +113,20 @@ class ParameterManager:
     def _clear_pint_models_cache(self):
         """Clear the PINT models cache."""
         self._pint_models_cache = None
+
+    def _normalize_excluded_consistent_parameters(
+        self, exclude_from_consistent: List[str] | tuple[str, ...]
+    ) -> set[str]:
+        """Return canonical PINT names excluded from consistent component merging."""
+        return {
+            resolve_parameter_alias(param).upper()
+            for param in tuple(exclude_from_consistent)
+        }
+
+    def _is_excluded_from_consistent(self, param_name: str) -> bool:
+        return (
+            resolve_parameter_alias(param_name).upper() in self.exclude_from_consistent
+        )
 
     # ===== MAIN PUBLIC METHODS =====
 
@@ -688,30 +711,31 @@ class ParameterManager:
         component_params: List[str],
     ) -> None:
         """Make parameters for a specific component consistent."""
-        # If no parameters to process, nothing to do
-        if not component_params:
+        consistent_params = [
+            param
+            for param in component_params
+            if not self._is_excluded_from_consistent(param)
+        ]
+
+        if not consistent_params:
             self.logger.debug(
-                f"No parameters found for component {component}, skipping"
+                f"No non-excluded parameters found for component {component}, skipping"
             )
             return
 
-        # Extract reference values
         reference_values = {}
-        for param in component_params:
+        for param in consistent_params:
             if param in reference_dict:
                 reference_values[param] = reference_dict[param]
 
-        # Apply to all PTAs
         for pta_name, parfile_dict in parfile_dicts.items():
             if pta_name == reference_pta:
-                continue  # Skip reference PTA
+                continue
 
-            # Remove ALL existing parameters for this component
-            for param in component_params:
+            for param in consistent_params:
                 if param in parfile_dict:
                     parfile_dict.pop(param)
 
-            # Add reference values
             for param, value in reference_values.items():
                 parfile_dict[param] = value
 
@@ -724,49 +748,40 @@ class ParameterManager:
     ) -> None:
         """Handle DM-specific special cases: DMX removal, DMEPOCH, DM1/DM2 derivatives."""
 
-        # Handle DM and DMEPOCH explicitly - always add to all PTAs
-        dm_value = reference_dict.get("DM")
-        if dm_value is None:
-            raise ValueError(
-                "DM parameter is missing from reference parfile. "
-                "DM parameter is required when add_dm_derivatives=True. "
-                "Please ensure the reference parfile contains a DM parameter."
-            )
-
-        # Parse DM parameter using PINT's Parameter class
-        reference_dm, dm_is_frozen = parse_parameter_using_pint("DM", dm_value)
-
-        if dm_is_frozen:
-            self.logger.warning(
-                f"DM parameter in reference parfile for {self.reference_pta} is not free. "
-                "Setting to free."
-            )
-
-        # Handle DMEPOCH explicitly - always add to all PTAs
         dmepoch_value = reference_dict.get("DMEPOCH", ["55000"])
         reference_dmepoch, _ = parse_parameter_using_pint("DMEPOCH", dmepoch_value)
         self.logger.debug(f"Reference DMEPOCH: {reference_dmepoch}")
 
-        # Process each PTA (including reference PTA)
         for pta_name, parfile_dict in parfile_dicts.items():
-            # Remove DMX parameters using pre-computed list
             dmx_params = dmx_params_map[pta_name]
             for dmx_param in dmx_params:
                 old_value = parfile_dict[dmx_param]
                 parfile_dict.pop(dmx_param)
                 self.logger.debug(f"PTA {pta_name}: Removed {dmx_param} = {old_value}")
 
-            # Set DM for ALL PTAs (so we ensure it's always being fit for)
-            parfile_dict["DM"] = [f"{reference_dm} 1"]  # 1 = free
-            self.logger.debug(f"PTA {pta_name}: Set DM = {reference_dm} (free)")
+            dm_value = parfile_dict.get("DM")
+            if dm_value is None:
+                raise ValueError(
+                    f"DM parameter is missing from parfile for PTA {pta_name}. "
+                    "DM is required for consistent dispersion cleanup because it "
+                    "is kept as that PTA's local reference DM."
+                )
 
-            # Set DMEPOCH for ALL PTAs (need it for DM1 and DM2)
-            parfile_dict["DMEPOCH"] = [f"{reference_dmepoch} 0"]  # 0 = frozen
+            local_dm, dm_is_frozen = parse_parameter_using_pint("DM", dm_value)
+            if dm_is_frozen:
+                self.logger.warning(
+                    f"DM parameter in parfile for PTA {pta_name} is not free. "
+                    "Setting to free."
+                )
+
+            parfile_dict["DM"] = [f"{local_dm} 1"]
+            self.logger.debug(f"PTA {pta_name}: Preserved local DM = {local_dm} (free)")
+
+            parfile_dict["DMEPOCH"] = [f"{reference_dmepoch} 0"]
             self.logger.debug(
                 f"PTA {pta_name}: Set DMEPOCH = {reference_dmepoch} (frozen)"
             )
 
-            # Handle DM derivatives based on add_dm_derivatives flag
             if add_dm_derivatives:
                 parfile_dict["DM1"] = ["0.0 1"]
                 parfile_dict["DM2"] = ["0.0 1"]
@@ -829,7 +844,11 @@ class ParameterManager:
 
             pint_models = self.pint_models  # Use cached models
             params = get_parameters_by_type_from_models(component_type, pint_models)
-            mergeable_params.extend(params)
+            mergeable_params.extend(
+                param
+                for param in params
+                if not self._is_excluded_from_consistent(param)
+            )
         return mergeable_params
 
     def _process_all_pta_parameters(

--- a/src/metapulsar/parameter_manager.py
+++ b/src/metapulsar/parameter_manager.py
@@ -7,6 +7,8 @@ This module consolidates all parameter management functionality:
 - Working with both PINT and Tempo2 PTAs
 """
 
+from __future__ import annotations
+
 import tempfile
 import subprocess
 from pathlib import Path

--- a/tests/test_parameter_manager.py
+++ b/tests/test_parameter_manager.py
@@ -7,8 +7,11 @@ for multi-PTA pulsar data.
 
 import pytest
 import tempfile
+from io import StringIO
 from pathlib import Path
 from unittest.mock import Mock, patch, mock_open
+
+from pint.models.model_builder import parse_parfile
 
 from metapulsar.parameter_manager import (
     ParameterManager,
@@ -872,6 +875,26 @@ UNITS TDB
         }
 
         assert "DM" in mergeable
+
+        parfile_data = {
+            pta: data["par_content"]
+            for pta, data in file_data_with_two_different_dm_values.items()
+        }
+        consistent_parfiles = parameter_manager._make_parameters_consistent(
+            parfile_data
+        )
+
+        for pta_name in file_data_with_two_different_dm_values:
+            parfile_dict = parse_parfile(StringIO(consistent_parfiles[pta_name]))
+            assert parfile_dict["DM"] == ["13.2 1"]
+
+        mapping = parameter_manager.build_parameter_mappings()
+
+        assert "DM" in mapping.merged_parameters
+        assert "DM1" in mapping.merged_parameters
+        assert "DM2" in mapping.merged_parameters
+        assert "DM_EPTA" not in mapping.pta_specific_parameters
+        assert "DM_PPTA" not in mapping.pta_specific_parameters
 
     @pytest.fixture
     def file_data_with_two_different_f0_values(self):

--- a/tests/test_parameter_manager.py
+++ b/tests/test_parameter_manager.py
@@ -15,6 +15,10 @@ from metapulsar.parameter_manager import (
     ParameterInconsistencyError,
     ParameterMapping,
 )
+from metapulsar.pint_helpers import (
+    get_parameters_by_type_from_models,
+    resolve_parameter_alias,
+)
 from tests.helpers import make_tim_metadata
 
 # Mark all tests as slow
@@ -395,42 +399,56 @@ UNITS TDB
         assert mapping.pta_specific_parameters == []
 
     def test_handle_dm_special_cases_missing_dm_error(self):
-        """Test that _handle_dm_special_cases raises error when DM is missing from reference dict."""
-        # Create file data without DM parameter
+        """Test that _handle_dm_special_cases raises when any PTA lacks DM."""
         file_data_without_dm = {
             "EPTA": {
                 "par": Path("test_parfiles/epta.par"),
                 "tim": Path("test_parfiles/epta.tim"),
                 "tim_metadata": make_tim_metadata(timespan_days=3650.5),
                 "timing_package": "pint",
-                "par_content": "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\nF1 -6.2e-16\nRAJ 18:57:36.3937\nDECJ +09:43:17.291\nUNITS TDB\n",
+                "par_content": (
+                    "PSR J1857+0943\n"
+                    "PEPOCH 55000\n"
+                    "F0 186.494081\n"
+                    "F1 -6.2e-16\n"
+                    "RAJ 18:57:36.3937\n"
+                    "DECJ +09:43:17.291\n"
+                    "DM 13.299\n"
+                    "UNITS TDB\n"
+                ),
             },
             "PPTA": {
                 "par": Path("test_parfiles/ppta.par"),
                 "tim": Path("test_parfiles/ppta.tim"),
                 "tim_metadata": make_tim_metadata(timespan_days=4200.3),
                 "timing_package": "tempo2",
-                "par_content": "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\nF1 -6.2e-16\nRAJ 18:57:36.3937\nDECJ +09:43:17.291\nUNITS TDB\n",
+                "par_content": (
+                    "PSR J1857+0943\n"
+                    "PEPOCH 55000\n"
+                    "F0 186.494081\n"
+                    "F1 -6.2e-16\n"
+                    "RAJ 18:57:36.3937\n"
+                    "DECJ +09:43:17.291\n"
+                    "UNITS TDB\n"
+                ),
             },
         }
 
-        # Create ParameterManager with add_dm_derivatives=True to trigger DM handling
         parameter_manager = ParameterManager(
             file_data=file_data_without_dm,
             combine_components=["dispersion"],
             add_dm_derivatives=True,
         )
 
-        # Parse parfiles to get the reference dict
         parfile_dicts = parameter_manager._parse_parfiles()
-        reference_dict = parfile_dicts["EPTA"]  # First PTA is used as reference
+        reference_dict = parfile_dicts["EPTA"]
 
-        # Verify DM is not in reference dict
-        assert "DM" not in reference_dict
+        assert "DM" in reference_dict
+        assert "DM" not in parfile_dicts["PPTA"]
 
-        # Test that _handle_dm_special_cases raises an error when DM is missing
         with pytest.raises(
-            ValueError, match="DM parameter is missing from reference parfile"
+            ValueError,
+            match="DM parameter is missing from parfile for PTA PPTA",
         ):
             parameter_manager._handle_dm_special_cases(
                 parfile_dicts=parfile_dicts,
@@ -731,6 +749,221 @@ UNITS TDB
         assert parfile_dicts["EPTA"]["DMEPOCH"] == ["55000.0 0"]
         assert parfile_dicts["EPTA"]["DM1"] == ["0.0 1"]
         assert parfile_dicts["EPTA"]["DM2"] == ["0.0 1"]
+
+    @pytest.fixture
+    def file_data_with_two_different_dm_values(self):
+        return {
+            "EPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "PEPOCH 55000\n"
+                    "F0 186.494081\n"
+                    "RAJ 16:00:51.9032\n"
+                    "DECJ -30:53:49.38\n"
+                    "DM 13.2 1\n"
+                    "DMEPOCH 54000\n"
+                    "DM1 0.0 1\n"
+                    "DM2 0.0 1\n"
+                    "EPHEM DE440\n"
+                    "CLOCK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+            "PPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "PEPOCH 55000\n"
+                    "F0 186.494081\n"
+                    "RAJ 16:00:51.9032\n"
+                    "DECJ -30:53:49.38\n"
+                    "DM 13.7 1\n"
+                    "DMEPOCH 56000\n"
+                    "DM1 0.0 1\n"
+                    "DM2 0.0 1\n"
+                    "EPHEM DE440\n"
+                    "CLOCK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+        }
+
+    def test_consistent_dispersion_preserves_local_dm_by_default(
+        self, file_data_with_two_different_dm_values
+    ):
+        parameter_manager = ParameterManager(
+            file_data=file_data_with_two_different_dm_values,
+            combine_components=["dispersion"],
+            add_dm_derivatives=True,
+        )
+
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+        parameter_manager._make_component_parameters_consistent(
+            parfile_dicts,
+            reference_dict,
+            "EPTA",
+            "dispersion",
+            ["DM", "DMEPOCH", "DM1", "DM2"],
+        )
+        parameter_manager._handle_dm_special_cases(
+            parfile_dicts=parfile_dicts,
+            reference_dict=reference_dict,
+            add_dm_derivatives=True,
+            dmx_params_map={"EPTA": [], "PPTA": []},
+        )
+
+        assert parfile_dicts["EPTA"]["DM"] == ["13.2 1"]
+        assert parfile_dicts["PPTA"]["DM"] == ["13.7 1"]
+        assert parfile_dicts["EPTA"]["DMEPOCH"] == ["54000.0 0"]
+        assert parfile_dicts["PPTA"]["DMEPOCH"] == ["54000.0 0"]
+        assert parfile_dicts["EPTA"]["DM1"] == ["0.0 1"]
+        assert parfile_dicts["PPTA"]["DM1"] == ["0.0 1"]
+
+    def test_discover_mergeable_parameters_excludes_dm_by_default(
+        self, file_data_with_two_different_dm_values
+    ):
+        parameter_manager = ParameterManager(
+            file_data=file_data_with_two_different_dm_values,
+            combine_components=["dispersion"],
+            add_dm_derivatives=True,
+        )
+
+        mergeable = {
+            resolve_parameter_alias(param)
+            for param in parameter_manager._discover_mergeable_parameters()
+        }
+
+        assert "DM" not in mergeable
+        assert "DM1" in mergeable
+        assert "DM2" in mergeable
+
+    def test_build_parameter_mappings_keeps_dm_pta_specific_by_default(
+        self, file_data_with_two_different_dm_values
+    ):
+        parameter_manager = ParameterManager(
+            file_data=file_data_with_two_different_dm_values,
+            combine_components=["dispersion"],
+            add_dm_derivatives=True,
+        )
+
+        mapping = parameter_manager.build_parameter_mappings()
+
+        assert "DM_EPTA" in mapping.pta_specific_parameters
+        assert "DM_PPTA" in mapping.pta_specific_parameters
+        assert "DM1" in mapping.merged_parameters
+        assert "DM2" in mapping.merged_parameters
+        assert "DM" not in mapping.merged_parameters
+
+    def test_empty_exclude_from_consistent_restores_merged_dm(
+        self, file_data_with_two_different_dm_values
+    ):
+        parameter_manager = ParameterManager(
+            file_data=file_data_with_two_different_dm_values,
+            combine_components=["dispersion"],
+            add_dm_derivatives=True,
+            exclude_from_consistent=[],
+        )
+
+        mergeable = {
+            resolve_parameter_alias(param)
+            for param in parameter_manager._discover_mergeable_parameters()
+        }
+
+        assert "DM" in mergeable
+
+    @pytest.fixture
+    def file_data_with_two_different_f0_values(self):
+        return {
+            "EPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "PEPOCH 55000\n"
+                    "F0 186.494081 1\n"
+                    "F1 -6.2e-16 1\n"
+                    "RAJ 16:00:51.9032\n"
+                    "DECJ -30:53:49.38\n"
+                    "DM 13.2 1\n"
+                    "EPHEM DE440\n"
+                    "CLOCK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+            "PPTA": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1600-3053\n"
+                    "PEPOCH 55000\n"
+                    "F0 186.500000 1\n"
+                    "F1 -6.2e-16 1\n"
+                    "RAJ 16:00:51.9032\n"
+                    "DECJ -30:53:49.38\n"
+                    "DM 13.7 1\n"
+                    "EPHEM DE440\n"
+                    "CLOCK TT(BIPM2021)\n"
+                    "UNITS TDB\n"
+                ),
+            },
+        }
+
+    def test_exclude_from_consistent_keeps_f0_pta_specific(
+        self, file_data_with_two_different_f0_values
+    ):
+        parameter_manager = ParameterManager(
+            file_data=file_data_with_two_different_f0_values,
+            combine_components=["spindown"],
+            exclude_from_consistent=("F0",),
+        )
+
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+        spindown_params = get_parameters_by_type_from_models(
+            "spindown", parameter_manager.pint_models
+        )
+        parameter_manager._make_component_parameters_consistent(
+            parfile_dicts,
+            reference_dict,
+            "EPTA",
+            "spindown",
+            spindown_params,
+        )
+
+        assert parfile_dicts["EPTA"]["F0"] == ["186.494081 1"]
+        assert parfile_dicts["PPTA"]["F0"] == ["186.500000 1"]
+
+        mapping = parameter_manager.build_parameter_mappings()
+
+        assert "F0_EPTA" in mapping.pta_specific_parameters
+        assert "F0_PPTA" in mapping.pta_specific_parameters
+        assert "F0" not in mapping.merged_parameters
+        assert "F1" in mapping.merged_parameters
+
+    def test_exclude_from_consistent_accepts_lowercase_dm_alias(
+        self, file_data_with_two_different_dm_values
+    ):
+        parameter_manager = ParameterManager(
+            file_data=file_data_with_two_different_dm_values,
+            combine_components=["dispersion"],
+            add_dm_derivatives=True,
+            exclude_from_consistent=("dm",),
+        )
+
+        assert parameter_manager.exclude_from_consistent == {"DM"}
+
+        mergeable = {
+            resolve_parameter_alias(param)
+            for param in parameter_manager._discover_mergeable_parameters()
+        }
+
+        assert "DM" not in mergeable
+
+        mapping = parameter_manager.build_parameter_mappings()
+
+        assert "DM_EPTA" in mapping.pta_specific_parameters
+        assert "DM_PPTA" in mapping.pta_specific_parameters
+        assert "DM" not in mapping.merged_parameters
 
     def test_apply_consistent_convention_rules_mixed_astrometry_raises(self):
         """Mixed ecliptic/equatorial astrometry should fail fast."""


### PR DESCRIPTION
## Summary

Keep each PTA’s reference `DM` when making dispersion models consistent across datasets, while still sharing `DM1`/`DM2` and applying the usual DMX cleanup. Adds a user-facing `exclude_from_consistent` option (default `("DM",)`) threaded through `ParameterManager`, `MetaPulsar`, and the factory.

## Motivation

Under the consistent-combination strategy, MetaPulsar previously copied the reference PTA’s `DM` into every parfile and exposed a single merged `DM` fit parameter. That is not always correct: the parfile `DM` is each PTA’s reference value for TOA production, and those references can differ between datasets. The stochastic DM process belongs in the noise model; the deterministic Taylor expansion (`DM`, `DM1`, `DM2`, shared `DMEPOCH`) should stay consistent without forcing a shared reference `DM`.

## What changed

**Default behavior (no API change required for typical use):**
- Each PTA keeps its own `DM` value in consistent parfiles (marked free).
- DMX terms are still removed; `DMEPOCH` is still taken from the reference and frozen; `DM1`/`DM2` are still added/shared when `add_dm_derivatives=True`.
- Parameter mapping exposes `DM_<pta>` (e.g. `DM_EPTA`, `DM_PPTA`) instead of a merged `DM`.

**New option: `exclude_from_consistent`**
- Available on `ParameterManager`, `MetaPulsar`, `MetaPulsarFactory.create_metapulsar`, `create_all_metapulsars`, and module-level wrappers.
- Default: `("DM",)`.
- Pass `[]` to restore previous behavior: merge `DM` across PTAs and expose a single merged `DM` fit parameter.
- Can exclude other parameters too (e.g. `("F0",)` with `combine_components=["spindown"]`).
- Names are alias-resolved and matched case-insensitively (`("dm",)` works).

**Documentation**
- `docs/METHOD_DESCRIPTION.md` updated to describe PTA-local `DM` by default and the `DM_<pta>` mapping.

## How it works

For dispersion, consistency is applied in two steps:
1. `_make_component_parameters_consistent` merges component parameters not in `exclude_from_consistent`.
2. `_handle_dm_special_cases` always handles DMX removal, `DMEPOCH`, and `DM1`/`DM2`; with the default exclusion, it preserves each PTA’s local `DM` rather than overwriting with the reference.

With `exclude_from_consistent=[]`, step 1 merges `DM` first; step 2 then normalizes the already-unified values — legacy merged-`DM` behavior is preserved.

## Tests

- Default: local `DM` preserved in parfiles; `DM` excluded from mergeable params; `DM_<pta>` mapping.
- `exclude_from_consistent=[]`: end-to-end merged `DM` in parfiles and mapping (not just mergeable discovery).
- Generic exclusion: `F0` kept PTA-specific under consistent spindown.
- Case insensitivity: `("dm",)` treated as `("DM",)`.
- Updated missing-`DM` error expectations for per-PTA requirements under the default.

## Test plan

- [x] `make fast` passes
- [x] Focused `tests/test_parameter_manager.py` coverage for default, empty exclude, F0 exclusion, and lowercase aliases
- [ ] Spot-check a multi-PTA notebook/workflow that previously assumed a merged `DM` fit parameter — update to `DM_<pta>` or pass `exclude_from_consistent=[]` if merged `DM` is still desired