### PR TITLE
**fix(parameter-manager): align NE_SW across PTAs for tempo2/PINT parity**

### DIFF
--- a/docs/METHOD_DESCRIPTION.md
+++ b/docs/METHOD_DESCRIPTION.md
@@ -118,6 +118,17 @@ regression narrative.
 | Multi PTA, PINT + tempo2 | Remove/neutralize | Force `IERS2003` |
 | Equatorial + cross-engine | Remove + warning | Strip `ECL` |
 
+#### Solar-wind convention (`NE_SW`)
+
+Tempo2 applies an implicit `NE_SW = 4` cm⁻³ when the line is absent; PINT applies none.
+During consistent parfile rewriting MetaPulsar aligns an explicit frozen `NE_SW` line when:
+
+1. the reference par has explicit `NE_SW` (that value is used on all PTAs), or
+2. any PTA uses tempo2 (`NE_SW 4 0` on all PTAs).
+
+For PINT-only stacks with no reference `NE_SW`, no line is added (PINT effective zero).
+Conflicting explicit values on non-reference PTAs are overwritten with a warning.
+
 ### Step 4: Build Enterprise pulsars and validate identity
 
 For each PTA MetaPulsar builds an Enterprise pulsar object:
@@ -214,6 +225,7 @@ Any re‑timing that yields the **same column space** of ( **M** ) produces the 
 * **Unit conversions:** `ParameterManager._convert_units_if_needed`, `_convert_pint_to_tdb`, `_convert_tempo2_to_tdb`.
 * **Component merge:** `_make_component_parameters_consistent`, `_handle_dm_special_cases`.
 * **Consistent convention rules:** `ParameterManager._apply_consistent_convention_rules` (called at the end of `_make_parameters_consistent`). Astrometry style detection: `detect_astrometry_style` in `pint_helpers.py`.
+* **NE_SW convention alignment:** `ParameterManager._align_ne_sw_convention`
 * **Component discovery/aliasing:** `get_parameters_by_type_from_models`, `resolve_parameter_alias`, `check_component_available_in_model`.
 * **Detector‑specific timing‑model parameters remain local:** anything not in the consistent component set becomes PTA‑suffixed in `_add_pta_specific_parameter`.
 * **Phase offset exposure:** if `PHOFF` is absent MetaPulsar defines a meta‑parameter mapped to the canonical “Offset” column so that per‑dataset constant phase terms are explicit.

--- a/src/metapulsar/parameter_manager.py
+++ b/src/metapulsar/parameter_manager.py
@@ -371,6 +371,53 @@ class ParameterManager:
             return None
         return parts[0].upper()
 
+    def _parse_ne_sw_value(self, parfile_dict: Dict[str, List[str]]) -> Optional[float]:
+        """Return explicit NE_SW (cm^-3) from a parfile dict, or None if absent."""
+        raw = parfile_dict.get("NE_SW")
+        if not raw:
+            return None
+        value, _frozen = parse_parameter_using_pint("NE_SW", raw)
+        return float(value)
+
+    def _resolve_consistent_ne_sw(
+        self,
+        reference_dict: Dict[str, List[str]],
+        normalized_packages: Set[str],
+    ) -> Optional[float]:
+        """Resolve the consistent NE_SW density (cm^-3) for this pulsar stack."""
+        explicit = self._parse_ne_sw_value(reference_dict)
+        if explicit is not None:
+            return explicit
+        if "tempo2" in normalized_packages:
+            return 4.0
+        return None
+
+    def _align_ne_sw_convention(
+        self,
+        parfile_dicts: Dict[str, Dict[str, List[str]]],
+        reference_dict: Dict[str, List[str]],
+    ) -> None:
+        """Align explicit NE_SW across PTAs to resolve tempo2/PINT default mismatch."""
+        normalized = self._normalized_timing_packages()
+        consistent_ne_sw = self._resolve_consistent_ne_sw(reference_dict, normalized)
+        if consistent_ne_sw is None:
+            self.logger.info("NE_SW alignment skipped (reason=pint_only_implicit_zero)")
+            return
+
+        line = [f"{consistent_ne_sw:g} 0"]
+        for pta_name, parfile_dict in parfile_dicts.items():
+            old = self._parse_ne_sw_value(parfile_dict)
+            if old is not None and abs(old - consistent_ne_sw) > 1e-9:
+                self.logger.warning(
+                    f"PTA {pta_name}: overwriting NE_SW {old:g} with consistent "
+                    f"value {consistent_ne_sw:g} from reference/resolution policy"
+                )
+            elif old is None:
+                self.logger.info(
+                    f"PTA {pta_name}: NE_SW aligned to {consistent_ne_sw:g} (was absent)"
+                )
+            parfile_dict["NE_SW"] = line
+
     def _collect_convention_states(
         self, parfile_dicts: Dict[str, Dict[str, List[str]]]
     ) -> Dict[str, Dict[str, Optional[str]]]:
@@ -588,6 +635,7 @@ class ParameterManager:
           reference PTA
         - For dispersion, remove DMX parameters
         - Optionally, add DM1 and DM2 parameters
+        - Align explicit NE_SW when required for tempo2/PINT parity
         - Always align CLOCK and EPHEM parameters
         - Convert back to par file strings
         - Write consistent par files to output directory
@@ -656,6 +704,8 @@ class ParameterManager:
                     self.add_dm_derivatives,
                     dmx_params_map,
                 )
+
+        self._align_ne_sw_convention(parfile_dicts, reference_dict)
 
         # Apply reference and engine-specific conventions after component updates.
         try:

--- a/tests/test_parameter_manager.py
+++ b/tests/test_parameter_manager.py
@@ -5,6 +5,7 @@ Tests the unified parameter and par file management functionality
 for multi-PTA pulsar data.
 """
 
+import logging
 import pytest
 import tempfile
 from pathlib import Path
@@ -840,3 +841,184 @@ UNITS TDB
             parameter_manager._apply_consistent_convention_rules(
                 parfile_dicts, reference_dict
             )
+
+    def test_parse_ne_sw_value_present_and_absent(self):
+        """Parse explicit NE_SW from parfile dict or return None when absent."""
+        parameter_manager = ParameterManager(
+            file_data={"EPTA": {"timing_package": "pint", "par_content": ""}},
+            combine_components=[],
+        )
+        assert parameter_manager._parse_ne_sw_value({"NE_SW": ["4 0"]}) == 4.0
+        assert parameter_manager._parse_ne_sw_value({}) is None
+
+    def test_resolve_consistent_ne_sw_reference_explicit(self):
+        """Reference explicit NE_SW takes precedence over tempo2 fallback."""
+        parameter_manager = ParameterManager(
+            file_data={
+                "EPTA": {"timing_package": "pint", "par_content": ""},
+                "PPTA": {"timing_package": "tempo2", "par_content": ""},
+            },
+            combine_components=[],
+        )
+        reference = {"NE_SW": ["0 0"]}
+        packages = parameter_manager._normalized_timing_packages()
+        assert parameter_manager._resolve_consistent_ne_sw(reference, packages) == 0.0
+
+    def test_resolve_consistent_ne_sw_tempo2_fallback(self):
+        """Missing reference NE_SW with tempo2 PTA resolves to 4.0 cm^-3."""
+        parameter_manager = ParameterManager(
+            file_data={
+                "EPTA": {"timing_package": "pint", "par_content": ""},
+                "PPTA": {"timing_package": "tempo2", "par_content": ""},
+            },
+            combine_components=[],
+        )
+        packages = parameter_manager._normalized_timing_packages()
+        assert parameter_manager._resolve_consistent_ne_sw({}, packages) == 4.0
+
+    def test_resolve_consistent_ne_sw_pint_only_skip(self):
+        """PINT-only stack with no reference NE_SW leaves alignment unresolved."""
+        parameter_manager = ParameterManager(
+            file_data={
+                "EPTA": {"timing_package": "pint", "par_content": ""},
+                "PPTA": {"timing_package": "pint", "par_content": ""},
+            },
+            combine_components=[],
+        )
+        packages = parameter_manager._normalized_timing_packages()
+        assert parameter_manager._resolve_consistent_ne_sw({}, packages) is None
+
+    def test_align_ne_sw_cross_engine_missing(self):
+        """Cross-engine stack without NE_SW lines gets tempo2 fallback on all PTAs."""
+        file_data = {
+            "NG": {
+                "timing_package": "pint",
+                "par_content": "PSR J1857+0943\nUNITS TDB\n",
+            },
+            "EPTA": {
+                "timing_package": "tempo2",
+                "par_content": "PSR J1857+0943\nUNITS TDB\n",
+            },
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["NG"]
+
+        parameter_manager._align_ne_sw_convention(parfile_dicts, reference_dict)
+
+        assert parfile_dicts["NG"]["NE_SW"] == ["4 0"]
+        assert parfile_dicts["EPTA"]["NE_SW"] == ["4 0"]
+
+    def test_align_ne_sw_tempo2_only_single_pta_missing(self):
+        """Single tempo2 PTA without NE_SW gets explicit tempo2 default."""
+        file_data = {
+            "EPTA": {
+                "timing_package": "tempo2",
+                "par_content": "PSR J1857+0943\nUNITS TDB\n",
+            },
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        parameter_manager._align_ne_sw_convention(parfile_dicts, reference_dict)
+
+        assert parfile_dicts["EPTA"]["NE_SW"] == ["4 0"]
+
+    def test_align_ne_sw_pint_only_multi_pta_missing(self):
+        """PINT-only multi-PTA stack leaves NE_SW absent when reference omits it."""
+        file_data = {
+            "EPTA": {
+                "timing_package": "pint",
+                "par_content": "PSR J1857+0943\nUNITS TDB\n",
+            },
+            "PPTA": {
+                "timing_package": "pint",
+                "par_content": "PSR J1857+0943\nUNITS TDB\n",
+            },
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        parameter_manager._align_ne_sw_convention(parfile_dicts, reference_dict)
+
+        assert "NE_SW" not in parfile_dicts["EPTA"]
+        assert "NE_SW" not in parfile_dicts["PPTA"]
+
+    def test_align_ne_sw_reference_explicit_zero(self, caplog):
+        """Reference NE_SW 0 overwrites conflicting explicit values with warning."""
+        file_data = {
+            "NG": {
+                "timing_package": "pint",
+                "par_content": "PSR J1857+0943\nNE_SW 0 0\nUNITS TDB\n",
+            },
+            "EPTA": {
+                "timing_package": "tempo2",
+                "par_content": "PSR J1857+0943\nNE_SW 4 0\nUNITS TDB\n",
+            },
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["NG"]
+
+        with caplog.at_level(logging.WARNING):
+            parameter_manager._align_ne_sw_convention(parfile_dicts, reference_dict)
+
+        assert parfile_dicts["NG"]["NE_SW"] == ["0 0"]
+        assert parfile_dicts["EPTA"]["NE_SW"] == ["0 0"]
+        assert any(
+            "overwriting NE_SW 4 with consistent value 0" in record.message
+            for record in caplog.records
+        )
+
+    def test_align_ne_sw_reference_explicit_four(self):
+        """Reference explicit NE_SW 4 is written on all PTAs including absent targets."""
+        file_data = {
+            "NG": {
+                "timing_package": "pint",
+                "par_content": "PSR J1857+0943\nNE_SW 4 0\nUNITS TDB\n",
+            },
+            "EPTA": {
+                "timing_package": "tempo2",
+                "par_content": "PSR J1857+0943\nUNITS TDB\n",
+            },
+        }
+        parameter_manager = ParameterManager(file_data=file_data, combine_components=[])
+        parfile_dicts = parameter_manager._parse_parfiles()
+        reference_dict = parfile_dicts["NG"]
+
+        parameter_manager._align_ne_sw_convention(parfile_dicts, reference_dict)
+
+        assert parfile_dicts["NG"]["NE_SW"] == ["4 0"]
+        assert parfile_dicts["EPTA"]["NE_SW"] == ["4 0"]
+
+    @patch.object(ParameterManager, "_apply_consistent_convention_rules")
+    def test_make_parameters_consistent_aligns_ne_sw_cross_engine(self, _mock_conv):
+        """_make_parameters_consistent aligns NE_SW before convention rules."""
+        file_data = {
+            "NG": {
+                "timing_package": "pint",
+                "par_content": (
+                    "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\n"
+                    "F1 -6.2e-16\nUNITS TDB\n"
+                ),
+            },
+            "EPTA": {
+                "timing_package": "tempo2",
+                "par_content": (
+                    "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\n"
+                    "F1 -6.2e-16\nUNITS TDB\n"
+                ),
+            },
+        }
+        parameter_manager = ParameterManager(
+            file_data=file_data,
+            combine_components=[],
+        )
+        parfile_data = {pta: data["par_content"] for pta, data in file_data.items()}
+
+        result = parameter_manager._make_parameters_consistent(parfile_data)
+
+        assert "NE_SW" in result["NG"] and "4" in result["NG"]
+        assert "NE_SW" in result["EPTA"] and "4" in result["EPTA"]


### PR DESCRIPTION
## Summary

Cross-engine MetaPulsar stacks can silently disagree on solar-wind dispersion because tempo2 applies an implicit `NE_SW = 4` cm⁻³ when the line is absent, while PINT applies none (effective zero). This PR adds explicit NE_SW alignment to the consistent parfile rewrite path so PINT and tempo2 PTAs evaluate the same solar-wind density.

**Resolution policy** (applied in `_make_parameters_consistent`, before EPHEM/ECL convention rules):

1. If the reference par has explicit `NE_SW`, that value is written (frozen) on all PTAs.
2. Else if any PTA uses tempo2, write `NE_SW 4 0` on all PTAs.
3. Else (PINT-only stack, no reference line), leave pars unchanged.

Conflicting explicit values on non-reference PTAs are overwritten with a warning.

## Changes

- **`ParameterManager`**: add `_parse_ne_sw_value`, `_resolve_consistent_ne_sw`, `_align_ne_sw_convention`; call from `_make_parameters_consistent`.
- **Tests**: 10 focused unit/integration tests (`pytest tests/test_parameter_manager.py -k ne_sw`).
- **Docs**: Step 3 solar-wind subsection in `METHOD_DESCRIPTION.md`.

## Out of scope

Composite strategy, `NE_SW_SIN`/`SWM`/SWX aliases, fit-parameter merging, JUG backend changes.

## Test plan

- [x] `pytest tests/test_parameter_manager.py -k ne_sw -q` (10 passed)
- [x] `make fast` in a fully provisioned dev environment
- [ ] Spot-check a cross-engine IPTA pulsar (e.g. Yu & Allen 5-PTA stack or all IPTA DR2 pulsars) and confirm rewritten pars contain aligned `NE_SW` where tempo2 is present

## Motivation

IPTA DR2 and multi-PTA stacks often omit `NE_SW` on PINT reference pars while tempo2 PTAs implicitly use 4 cm⁻³. Without an explicit line, cross-engine timing models can differ on solar-wind delay even when other conventions are aligned.