### PR TITLE
fix(identity): catalog names + 10″ J2000 matching

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -256,25 +256,25 @@ def discover_files(
 
 ### get_pulsar_names_from_file_data
 
-Extract pulsar names from file data using coordinate-based matching.
+Extract B-preferred catalog pulsar names from file data (10″ J2000 position grouping).
 
 ```python
 def get_pulsar_names_from_file_data(
     file_data: Dict[str, List[Dict[str, Any]]]
 ) -> List[str]:
-    """Extract pulsar names from file data using coordinate-based matching.
+    """Extract pulsar names from file data using position-based catalog identity.
     
     Args:
         file_data: File data from FileDiscoveryService
         
     Returns:
-        List of canonical J-names (e.g., 'J0613-0200')
+        List of catalog names (B-preferred when parfiles use B-names, e.g. 'B1855+09')
     """
 ```
 
 ### filter_file_data_by_pulsars
 
-Filter file data to specific pulsars.
+Filter file data to specific pulsars by catalog or path alias.
 
 ```python
 def filter_file_data_by_pulsars(
@@ -285,11 +285,23 @@ def filter_file_data_by_pulsars(
     
     Args:
         file_data: File data from FileDiscoveryService
-        pulsar_names: Single pulsar name or list of names (J or B formats accepted)
+        pulsar_names: Catalog names (PSRJ/PSR/PSRB) or path-derived aliases
         
     Returns:
         Filtered file data containing only specified pulsars
     """
+```
+
+### discover_pulsars_by_position
+
+Group discovered file pairs by on-sky position (default 10″ at J2000) and catalog identity.
+
+```python
+def discover_pulsars_by_position(
+    file_data: Dict[str, List[Dict[str, Any]]],
+    match_tol_arcsec: float = 10.0,
+) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
+    """Returns dict keyed by B-preferred catalog name → PTA → file records."""
 ```
 
 ## Layout Discovery

--- a/docs/METHOD_DESCRIPTION.md
+++ b/docs/METHOD_DESCRIPTION.md
@@ -146,7 +146,7 @@ For each PTA MetaPulsar builds an Enterprise pulsar object:
 * PINT path: `ep.PintPulsar(TOAs, TimingModel, planets=True)`.
 * Tempo2 path: `ep.Tempo2Pulsar(tempopulsar, planets=True)`.
 
-MetaPulsar validates that all PTAs refer to the **same sky position** by converting names to a canonical **J‑name** derived from coordinates. “B‑vs‑J” selection is only for **display**—coordinate matching is authoritative.
+MetaPulsar validates that all PTAs refer to the **same sky position** (pairwise separation ≤ 10″ at J2000 ICRS) and compatible catalog letter-suffix usage. The public **`MetaPulsar.name`** is the B-preferred **catalog** string from parfile `PSRJ`/`PSR`/`PSRB` fields (not a truncated coordinate designator).
 
 ### Step 5: Parameter mapping (merged vs PTA‑specific)
 
@@ -202,7 +202,7 @@ Any re‑timing that yields the **same column space** of ( **M** ) produces the 
 * **Choice of consistent components.** The default choice `{astrometry, spindown, binary, dispersion}` fits most pulsars. For problematic sources one can drop a component from the consistent set; all parameters of that component then remain PTA‑specific.
 * **DM modeling.** Removing DMX in favor of {DM, DMEPOCH, DM1, DM2} makes the deterministic DM part uniform. Stochastic DM variations are handled entirely in the noise model (e.g., a DM GP) during inference.
 * **Challenging timing models.** If a pulsar resides in a regime where ( **M** ) varies rapidly with ( β₀ ) (high‑order binary models, poorly constrained orbital evolution), manual inspection is recommended. For Pulsar Timing Array purposes this is typically not an important regime to take into account. Note that the factory allows a **composite** strategy (no merging model components) for such cases (aka: FrankenStat) that is slightly more forgiving in this regard.
-* **Name handling.** Pulsar identity is validated via **coordinates**. B‑ vs J‑name is a display convention only and does not enter any computation.
+* **Name handling.** Pulsar identity uses **10″ J2000 position matching** plus parfile catalog names. B‑ vs J‑name strings that refer to the same source are aliases of one group; truncated `JHHMM±DDMM` strings are not used for identity or lookup.
 * **Determinism and provenance.** Given the set of `.par`/`.tim` inputs, the chosen reference PTA, and the list of consistent components, the output is deterministic. The code can optionally write the **shared** `.par` files it constructs for full auditability.
 * **Single‑PTA behavior.** A single‑PTA pulsar may still have its `.par`/`.tim` artifacts rewritten for DM model cleanup and pulse‑number handling. What is skipped is only the multi‑PTA consistency/alignment step, because there is no cross‑PTA reference relationship to enforce.
 
@@ -241,5 +241,5 @@ Any re‑timing that yields the **same column space** of ( **M** ) produces the 
 * **Detector‑specific timing‑model parameters remain local:** anything not in the consistent component set becomes PTA‑suffixed in `_add_pta_specific_parameter`.
 * **Phase offset exposure:** if `PHOFF` is absent MetaPulsar defines a meta‑parameter mapped to the canonical “Offset” column so that per‑dataset constant phase terms are explicit.
 * **Combined design matrix:** `MetaPulsar._build_design_matrix` (with unit corrections in `_convert_design_matrix_units`) and the zero‑information cull in `_remove_nonidentifiable_parameters`.
-* **Identity validation and naming:** `bj_name_from_pulsar` and coordinate‑based checks in `_validate_pulsar_consistency`.
+* **Identity validation and naming:** `discover_pulsars_by_position`, `positions_within_tolerance`, and catalog suffix checks in `_validate_pulsar_consistency`; `MetaPulsar.name` from `preferred_group_name`.
 * **No TOA edits:** `MetaPulsar._combine_timing_data` concatenates; there are no writes or transforms of TOAs.

--- a/examples/notebooks/nonlinear_timing.ipynb
+++ b/examples/notebooks/nonlinear_timing.ipynb
@@ -1,704 +1,704 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "a08f1973",
-      "metadata": {},
-      "source": [
-        "# Nonlinear timing with MetaPulsar\n",
-        "\n",
-        "This notebook shows the sampler-facing **nonlinear timing** (NLT) workflow end to end:\n",
-        "\n",
-        "1. build a `MetaPulsar` from par/tim files,\n",
-        "2. configure a `NonLinearTimingModel` and resolve it **for the pulsar**,\n",
-        "3. assemble a Discovery likelihood and sample it with NumPyro NUTS,\n",
-        "4. write the **NLT run metadata** and decode the chain back to physical\n",
-        "   timing parameters — without any live model objects,\n",
-        "5. repeat the analysis for a **multi-PTA binary combination** with custom\n",
-        "   priors, sampled through **both** likelihood interfaces: Discovery/NUTS and\n",
-        "   Enterprise/PTMCMC.\n",
-        "\n",
-        "Instead of holding every timing parameter fixed at its par-file value (or\n",
-        "linearizing around it), the nonlinear timing model *numerically samples* a\n",
-        "chosen subset of timing parameters inside the likelihood, while the remaining\n",
-        "linear nuisance parameters are analytically marginalized.\n",
-        "\n",
-        "**Requirements**: `jug-timing` (JAX timing engine), `discovery`, `numpyro`,\n",
-        "`enterprise-pulsar`, and `PTMCMCSampler` — all available in the MetaPulsar\n",
-        "devcontainer. The datasets are simulated with PINT, so no external data\n",
-        "releases are needed."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "0076c5e4",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:07:58.219423Z",
-          "iopub.status.busy": "2026-07-17T17:07:58.219301Z",
-          "iopub.status.idle": "2026-07-17T17:07:58.226624Z",
-          "shell.execute_reply": "2026-07-17T17:07:58.225553Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "# JAX must see this before it is first imported.\n",
-        "import os\n",
-        "\n",
-        "os.environ.setdefault(\"JAX_ENABLE_X64\", \"1\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1c8a73ec",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:07:58.228438Z",
-          "iopub.status.busy": "2026-07-17T17:07:58.228306Z",
-          "iopub.status.idle": "2026-07-17T17:08:03.330622Z",
-          "shell.execute_reply": "2026-07-17T17:08:03.329660Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "import tempfile\n",
-        "from pathlib import Path\n",
-        "\n",
-        "import jax\n",
-        "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
-        "\n",
-        "from metapulsar import create_metapulsar\n",
-        "from metapulsar.sandbox_tempo2 import configure_logging\n",
-        "from nltiming import (\n",
-        "    NonLinearTimingModel,\n",
-        "    TimingInference,\n",
-        "    WhiteningConfig,\n",
-        "    load_run,\n",
-        "    sampling,\n",
-        "    save_discovery_checkpoint,\n",
-        ")\n",
-        "\n",
-        "configure_logging(level=\"WARNING\")\n",
-        "workdir = Path(tempfile.mkdtemp(prefix=\"nlt_demo_\"))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c131011b",
-      "metadata": {},
-      "source": [
-        "## 1. Simulate a demo dataset\n",
-        "\n",
-        "We simulate ~150 TOAs from PINT's bundled `NGC6440E` example par file. Because\n",
-        "the TOAs are drawn from the model itself (plus white noise), we know the true\n",
-        "parameter values exactly — useful for checking the posterior at the end."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6645202e",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:08:03.332517Z",
-          "iopub.status.busy": "2026-07-17T17:08:03.332347Z",
-          "iopub.status.idle": "2026-07-17T17:08:10.539341Z",
-          "shell.execute_reply": "2026-07-17T17:08:10.538643Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "import pint.config\n",
-        "from pint.models import get_model\n",
-        "from pint.simulation import make_fake_toas_uniform\n",
-        "\n",
-        "np.random.seed(42)\n",
-        "\n",
-        "model = get_model(pint.config.examplefile(\"NGC6440E.par\"))\n",
-        "toas = make_fake_toas_uniform(\n",
-        "    startMJD=53400,\n",
-        "    endMJD=56000,\n",
-        "    ntoas=150,\n",
-        "    model=model,\n",
-        "    obs=\"gbt\",\n",
-        "    error=1.0,  # us\n",
-        "    add_noise=True,\n",
-        ")\n",
-        "\n",
-        "par_path = workdir / \"demo.par\"\n",
-        "tim_path = workdir / \"demo.tim\"\n",
-        "par_path.write_text(model.as_parfile())\n",
-        "toas.write_TOA_file(str(tim_path), format=\"tempo2\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "247d1746",
-      "metadata": {},
-      "source": [
-        "## 2. Build the MetaPulsar\n",
-        "\n",
-        "`create_metapulsar` takes a `file_data` mapping of PTA name → par/tim entries.\n",
-        "Here we use a single \"PTA\"; a real multi-PTA combination simply adds more\n",
-        "entries (EPTA, PPTA, NANOGrav, …) to the same dictionary."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "14be1bab",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:08:10.540724Z",
-          "iopub.status.busy": "2026-07-17T17:08:10.540608Z",
-          "iopub.status.idle": "2026-07-17T17:08:20.352527Z",
-          "shell.execute_reply": "2026-07-17T17:08:20.351867Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "file_data = {\n",
-        "    \"demo\": [\n",
-        "        {\"par\": str(par_path), \"tim\": str(tim_path), \"timing_package\": \"pint\"}\n",
-        "    ]\n",
-        "}\n",
-        "mp = create_metapulsar(file_data, use_pulse_numbers=\"no\")\n",
-        "\n",
-        "print(f\"pulsar:  {mp.name}\")\n",
-        "print(f\"TOAs:    {len(mp.toas)}\")\n",
-        "print(f\"fitpars: {list(mp.fitpars)}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b30ef2a6",
-      "metadata": {},
-      "source": [
-        "## 3. Configure the nonlinear timing model\n",
-        "\n",
-        "Configuration is a **typed inference plan**: you name what is *marginalized*, and\n",
-        "every other timing axis is sampled. To sample just `F0`/`F1` we marginalize the\n",
-        "remaining (linear) nuisances as delta-flat — `TimingInference.groups(delta_flat=...)`.\n",
-        "(`TimingInference.sample_all()` samples every axis; `TimingInference.default()`\n",
-        "applies a versioned preset.) `for_pulsar()` resolves the configuration for the\n",
-        "pulsar and returns a `TimingContext`, which owns all per-pulsar queries.\n",
-        "\n",
-        "`whitening=WhiteningConfig()` selects the static posterior-whitening layer (the\n",
-        "sampler sees decorrelated coordinates); `engines=\"jug\"` uses the JAX timing\n",
-        "engine NUTS needs for autodiff. For binary pulsars you can pass priors right\n",
-        "here, e.g. `priors={\"TASC\": nlt_priors.delta_uniform(-0.5, 0.5, scale=\"PB\")}`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "44ab5821",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:08:20.353886Z",
-          "iopub.status.busy": "2026-07-17T17:08:20.353776Z",
-          "iopub.status.idle": "2026-07-17T17:08:22.991442Z",
-          "shell.execute_reply": "2026-07-17T17:08:22.990761Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "# Name what is marginalized; everything else is sampled. Here: sample F0/F1,\n",
-        "# marginalize the remaining linear nuisances as delta-flat.\n",
-        "nuisance = [p for p in mp.fitpars if p not in (\"F0\", \"F1\")]\n",
-        "ntm = NonLinearTimingModel(\n",
-        "    engines=\"jug\",\n",
-        "    inference=TimingInference.groups(delta_flat=nuisance),\n",
-        "    whitening=WhiteningConfig(),\n",
-        "    name=\"timing\",\n",
-        ")\n",
-        "ctx = ntm.for_pulsar(mp)\n",
-        "\n",
-        "print(f\"sampled:      {ctx.sampled}\")\n",
-        "print(f\"marginalized: {ctx.marginalized}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "71aafbfb",
-      "metadata": {},
-      "source": [
-        "### Inspecting and configuring the whitening transform\n",
-        "\n",
-        "The conditioned context carries its **metric provenance** and **transport\n",
-        "record**. Whitening is configured with the frozen `WhiteningConfig` dataclass\n",
-        "(`reference_noise`, `expansion_point`, `origin`) — never a stringly-typed dict.\n",
-        "The metric uses the exact prior curvature in the prior-normal coordinate `z`\n",
-        "produced by the **probability integral transform (PIT)** — under that map the\n",
-        "timing prior is exactly `z ~ Normal(0, I)`, so the posterior precision is\n",
-        "`F_z + I`. For an assembled-likelihood run, use the two-stage lifecycle: build an\n",
-        "unconditioned base with `for_pulsar(..., condition=False)`, then finalize it\n",
-        "once with `base.with_transport(metric)`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6e89f7fb",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# whitening=WhiteningConfig() builds the *posterior* metric C C^T = (F_z + I)^-1\n",
-        "# (the +I is the exact prior curvature in the PIT / prior-normal z coordinate),\n",
-        "# so the sampler sees a locally unit-covariance target. The metric provenance\n",
-        "# and the transport record travel with the conditioned context:\n",
-        "print(f\"transport:     {ctx.transport.kind}  (latent_decodable={ctx.transport.latent_decodable})\")\n",
-        "print(f\"metric source: {ctx.metric.source!r}  (approximate={ctx.metric.approximate})\")\n",
-        "\n",
-        "# WhiteningConfig controls how the affine layer (C, c) is built. `origin` sets\n",
-        "# where x = 0 maps (the center c):\n",
-        "#   \"reference\"       -> the par-file reference z_e  (deterministic; best for repro)\n",
-        "#   \"local_posterior\" -> a guarded local-MAP Newton step (needs a metric score)\n",
-        "#   \"auto\" (default)  -> local_posterior when a score is available, else reference\n",
-        "ntm_ref = NonLinearTimingModel(\n",
-        "    engines=\"jug\",\n",
-        "    inference=TimingInference.groups(delta_flat=nuisance),\n",
-        "    name=\"timing\",\n",
-        "    whitening=WhiteningConfig(reference_noise=\"toa_errors\", origin=\"reference\"),\n",
-        ")\n",
-        "print(f\"origin policy: {ntm_ref.for_pulsar(mp).transport.origin!r}\")\n",
-        "\n",
-        "# Two-stage lifecycle: an assembled likelihood interface can hand the context\n",
-        "# its own precision instead of the toa_errors default. The unconditioned base\n",
-        "# answers every pulsar-bound query; with_transport(metric) finalizes it once.\n",
-        "base = ntm.for_pulsar(mp, condition=False)      # base.transport is None\n",
-        "conditioned = base.with_transport(base.default_metric())\n",
-        "print(f\"unconditioned -> conditioned: {base.conditioned} -> {conditioned.conditioned}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "abe81094",
-      "metadata": {},
-      "source": [
-        "## 4. Discovery likelihood and NUTS sampling\n",
-        "\n",
-        "`ctx.discovery_signals()` returns Discovery-native signal objects (an\n",
-        "improper GP for the marginalized block plus a JAX nonlinear delay) that splat\n",
-        "directly into `PulsarLikelihood` — no changes to Discovery required.\n",
-        "\n",
-        "`sampling.numpyro.model` builds the standard NumPyro model (timing parameters\n",
-        "enter through one joint sample site with the physical prior attached), and\n",
-        "`sampling.numpyro.nuts` returns a configured `MCMC` with float64 enforced and\n",
-        "the chain initialized at the par-file reference."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "5931c1b3",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:08:22.992766Z",
-          "iopub.status.busy": "2026-07-17T17:08:22.992650Z",
-          "iopub.status.idle": "2026-07-17T17:08:27.272486Z",
-          "shell.execute_reply": "2026-07-17T17:08:27.271735Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "import discovery as ds\n",
-        "\n",
-        "noisedict = {f\"{mp.name}_efac\": 1.0, f\"{mp.name}_log10_t2equad\": -8.0}\n",
-        "\n",
-        "likelihood = ds.PulsarLikelihood(\n",
-        "    [\n",
-        "        mp.residuals,\n",
-        "        ds.makenoise_measurement_simple(mp, noisedict),\n",
-        "        *ctx.discovery_signals(),\n",
-        "    ]\n",
-        ")\n",
-        "\n",
-        "nlt_model = sampling.numpyro.model(likelihood, ctx, fixed=noisedict)\n",
-        "mcmc = sampling.numpyro.nuts(nlt_model, ctx, num_warmup=500, num_samples=1000)\n",
-        "mcmc.run(jax.random.PRNGKey(0))\n",
-        "\n",
-        "x = sampling.numpyro.timing_draws(mcmc.get_samples(), ctx)\n",
-        "print(f\"latent draws: {x.shape}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c69bccb8",
-      "metadata": {},
-      "source": [
-        "## 5. Run products: persist and decode without a live model\n",
-        "\n",
-        "`ctx.write(...)` snapshots everything needed to interpret the chain — the\n",
-        "serialized parameter space, units, digests — into small run metadata\n",
-        "(`nlt_run_meta.json` + `nlt_parameter_space.{json,npz}`). Later (or on another\n",
-        "machine), `load_run(...)` (which returns a `RunResults`) decodes the raw chain\n",
-        "into physical timing parameters from those files alone: no MetaPulsar, PTA\n",
-        "data, or timing engine required."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4a69469c",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:08:27.274037Z",
-          "iopub.status.busy": "2026-07-17T17:08:27.273734Z",
-          "iopub.status.idle": "2026-07-17T17:08:27.338456Z",
-          "shell.execute_reply": "2026-07-17T17:08:27.337761Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "outdir = workdir / \"run\"\n",
-        "manifest = ctx.write(\n",
-        "    outdir,\n",
-        "    likelihood=\"discovery\",\n",
-        "    sampler=\"numpyro-nuts\",\n",
-        "    latent={\"kind\": \"npz\", \"path\": \"discovery_x.npz\", \"key_name\": \"x\"},\n",
-        ")\n",
-        "save_discovery_checkpoint(outdir, x, manifest, final=True)\n",
-        "\n",
-        "results = load_run(outdir)\n",
-        "post = results.posterior(units=\"display\")\n",
-        "truths = results.truths()\n",
-        "\n",
-        "for name in ctx.sampled:\n",
-        "    lo, hi = np.percentile(post[name], [16, 84])\n",
-        "    print(f\"{name}: truth = {truths[name]:.12g}   68% interval = [{lo:.12g}, {hi:.12g}]\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "8a818c42",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:08:27.339725Z",
-          "iopub.status.busy": "2026-07-17T17:08:27.339610Z",
-          "iopub.status.idle": "2026-07-17T17:08:27.543512Z",
-          "shell.execute_reply": "2026-07-17T17:08:27.542780Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "fig, axes = plt.subplots(1, len(ctx.sampled), figsize=(10, 3.2))\n",
-        "for ax, name in zip(np.atleast_1d(axes), ctx.sampled):\n",
-        "    ax.hist(post[name], bins=40, density=True, alpha=0.7)\n",
-        "    ax.axvline(truths[name], color=\"k\", ls=\"--\", lw=1, label=\"truth\")\n",
-        "    ax.set_xlabel(name)\n",
-        "    ax.legend()\n",
-        "fig.tight_layout()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "aa08e48e",
-      "metadata": {},
-      "source": [
-        "## 6. Multi-PTA combination with a binary pulsar\n",
-        "\n",
-        "The same API scales to the real use case: several PTAs observing one (binary)\n",
-        "pulsar. We simulate two overlapping datasets from an ELL1 binary par file and\n",
-        "combine them into a single pulsar — each PTA contributes its own dataset (and\n",
-        "per-PTA phase offset), while the shared timing parameters are merged across\n",
-        "PTAs.\n",
-        "\n",
-        "Two things to note in the configuration below:\n",
-        "\n",
-        "- **Base-name selectors**: both the `TimingInference` groups and the `priors`\n",
-        "  keys match by base name — `\"PB\"` / `\"TASC\"` select those parameters however\n",
-        "  they are spelled on the combined pulsar (including PTA-suffixed variants under\n",
-        "  the `per_pta` strategy). Here we sample the binary parameters `PB`/`A1`/`TASC`\n",
-        "  and marginalize the rest.\n",
-        "- `priors=` with the spec helpers from `nltiming.priors`:\n",
-        "  `delta_uniform(-0.5, 0.5, scale=\"PB\")` puts a uniform prior on the `TASC`\n",
-        "  *offset* of ± half an orbital period — the bounds are multiplied by the PB\n",
-        "  reference when resolved for the pulsar (suffix-consistently under `per_pta`)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "471aa283",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:08:27.544904Z",
-          "iopub.status.busy": "2026-07-17T17:08:27.544784Z",
-          "iopub.status.idle": "2026-07-17T17:08:29.626308Z",
-          "shell.execute_reply": "2026-07-17T17:08:29.625694Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "BINARY_PAR = \"\"\"\\\n",
-        "PSRJ           J1234+4500\n",
-        "RAJ            12:34:00.0        1\n",
-        "DECJ           45:00:00.0        1\n",
-        "PMRA           0.0\n",
-        "PMDEC          0.0\n",
-        "F0             200.0             1\n",
-        "F1             -1.0e-15          1\n",
-        "PEPOCH         55000\n",
-        "POSEPOCH       55000\n",
-        "DMEPOCH        55000\n",
-        "DM             15.0              1\n",
-        "BINARY         ELL1\n",
-        "PB             12.3              1\n",
-        "A1             8.5               1\n",
-        "TASC           55000.1           1\n",
-        "EPS1           1.0e-6            1\n",
-        "EPS2           -2.0e-6           1\n",
-        "EPHEM          DE440\n",
-        "CLK            TT(BIPM2019)\n",
-        "UNITS          TDB\n",
-        "\"\"\"\n",
-        "\n",
-        "binary_par = workdir / \"binary.par\"\n",
-        "binary_par.write_text(BINARY_PAR)\n",
-        "binary_model = get_model(str(binary_par))\n",
-        "\n",
-        "np.random.seed(1)\n",
-        "spans = {\"pta_a\": (53000, 56500, \"gbt\"), \"pta_b\": (55000, 58000, \"parkes\")}\n",
-        "file_data2 = {}\n",
-        "for pta, (start, end, obs) in spans.items():\n",
-        "    fake = make_fake_toas_uniform(\n",
-        "        startMJD=start, endMJD=end, ntoas=120, model=binary_model, obs=obs,\n",
-        "        error=1.0, add_noise=True,\n",
-        "    )\n",
-        "    tim = workdir / f\"{pta}.tim\"\n",
-        "    fake.write_TOA_file(str(tim), format=\"tempo2\")\n",
-        "    file_data2[pta] = [\n",
-        "        {\"par\": str(binary_par), \"tim\": str(tim), \"timing_package\": \"pint\"}\n",
-        "    ]\n",
-        "\n",
-        "mp2 = create_metapulsar(file_data2, use_pulse_numbers=\"no\")\n",
-        "print(f\"pulsar:  {mp2.name}   TOAs: {len(mp2.toas)}  (2 PTAs)\")\n",
-        "print(f\"fitpars: {list(mp2.fitpars)}\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "38d5eb28",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:08:29.627712Z",
-          "iopub.status.busy": "2026-07-17T17:08:29.627587Z",
-          "iopub.status.idle": "2026-07-17T17:08:30.639613Z",
-          "shell.execute_reply": "2026-07-17T17:08:30.638918Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "from nltiming import priors as nlt_priors\n",
-        "\n",
-        "# Sample the binary parameters; marginalize everything else (delta-flat).\n",
-        "binary = [\"PB\", \"A1\", \"TASC\"]\n",
-        "nuisance2 = [p for p in mp2.fitpars if p not in binary]\n",
-        "ntm2 = NonLinearTimingModel(\n",
-        "    engines=\"jug\",\n",
-        "    inference=TimingInference.groups(delta_flat=nuisance2),\n",
-        "    priors={\"TASC\": nlt_priors.delta_uniform(-0.5, 0.5, scale=\"PB\")},\n",
-        "    whitening=WhiteningConfig(),\n",
-        "    name=\"timing\",\n",
-        ")\n",
-        "ctx2 = ntm2.for_pulsar(mp2)\n",
-        "\n",
-        "print(f\"sampled:       {ctx2.sampled}\")\n",
-        "print(f\"marginalized:  {ctx2.marginalized}\")\n",
-        "print(f\"prior sources: {ctx2.priors.sources}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9b4c920a",
-      "metadata": {},
-      "source": [
-        "The Discovery + NUTS pattern is identical to the single-PTA case — the\n",
-        "multi-PTA composite engine evaluates each PTA's rows with its own engine and\n",
-        "assembles them in canonical TOA order behind the scenes."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "75a06a55",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:08:30.640915Z",
-          "iopub.status.busy": "2026-07-17T17:08:30.640801Z",
-          "iopub.status.idle": "2026-07-17T17:08:36.726154Z",
-          "shell.execute_reply": "2026-07-17T17:08:36.725542Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "noisedict2 = {f\"{mp2.name}_efac\": 1.0, f\"{mp2.name}_log10_t2equad\": -8.0}\n",
-        "\n",
-        "likelihood2 = ds.PulsarLikelihood(\n",
-        "    [\n",
-        "        mp2.residuals,\n",
-        "        ds.makenoise_measurement_simple(mp2, noisedict2),\n",
-        "        *ctx2.discovery_signals(),\n",
-        "    ]\n",
-        ")\n",
-        "\n",
-        "nlt_model2 = sampling.numpyro.model(likelihood2, ctx2, fixed=noisedict2)\n",
-        "mcmc2 = sampling.numpyro.nuts(nlt_model2, ctx2, num_warmup=500, num_samples=1000)\n",
-        "mcmc2.run(jax.random.PRNGKey(1))\n",
-        "x2 = sampling.numpyro.timing_draws(mcmc2.get_samples(), ctx2)\n",
-        "\n",
-        "ds_dir = workdir / \"run_discovery_binary\"\n",
-        "manifest2 = ctx2.write(\n",
-        "    ds_dir,\n",
-        "    likelihood=\"discovery\",\n",
-        "    sampler=\"numpyro-nuts\",\n",
-        "    latent={\"kind\": \"npz\", \"path\": \"discovery_x.npz\", \"key_name\": \"x\"},\n",
-        ")\n",
-        "save_discovery_checkpoint(ds_dir, x2, manifest2, final=True)\n",
-        "post_ds = load_run(ds_dir).posterior(units=\"display\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b20745ec",
-      "metadata": {},
-      "source": [
-        "## 7. The same context with Enterprise + PTMCMC\n",
-        "\n",
-        "`ntm.enterprise_signal()` returns an Enterprise-native signal class that\n",
-        "combines with any other Enterprise signals and resolves per pulsar, exactly\n",
-        "like stock components. The `sampling.ptmcmc` module owns the sampler-vector ↔\n",
-        "likelihood-parameter mapping for the timing coordinate layout (the whitening\n",
-        "joint site used here under `WhiteningConfig()`, or the identity-layer `z`\n",
-        "coordinate under `whitening=None`), so no hand-written `vec_to_params` is needed.\n",
-        "\n",
-        "`sampling.ptmcmc.chain_layout(...)` records which chain columns hold the\n",
-        "timing coordinates in the run metadata — `load_run(...)` then decodes\n",
-        "the raw PTMCMC `chain_1.txt` directly, with burn-in and thinning applied\n",
-        "consistently to the latent and physical views."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "535fd6ae",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:08:36.727625Z",
-          "iopub.status.busy": "2026-07-17T17:08:36.727507Z",
-          "iopub.status.idle": "2026-07-17T17:11:44.192774Z",
-          "shell.execute_reply": "2026-07-17T17:11:44.191941Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "from enterprise.signals import parameter, signal_base, white_signals\n",
-        "\n",
-        "ef = white_signals.MeasurementNoise(efac=parameter.Constant(1.0))\n",
-        "ent_model = ef + ntm2.enterprise_signal()\n",
-        "pta = signal_base.PTA([ent_model(mp2)])\n",
-        "print(f\"pta params: {pta.param_names}\")\n",
-        "\n",
-        "ent_dir = workdir / \"run_enterprise_binary\"\n",
-        "pts = sampling.ptmcmc.timing_only_sampler(pta, ctx2, ent_dir, verbose=False)\n",
-        "pts.sample(\n",
-        "    p0=sampling.ptmcmc.initial_point(ctx2),\n",
-        "    Niter=20000,\n",
-        "    burn=2000,\n",
-        "    thin=1,\n",
-        ")\n",
-        "\n",
-        "layout = sampling.ptmcmc.chain_layout(ctx2, pta.param_names)\n",
-        "ctx2.write(ent_dir, likelihood=\"enterprise\", sampler=\"ptmcmc\", chain_layout=layout)\n",
-        "\n",
-        "post_ent = load_run(ent_dir).posterior(burn=0.25, units=\"display\")\n",
-        "truths2 = load_run(ent_dir).truths()\n",
-        "\n",
-        "for name in ctx2.sampled:\n",
-        "    lo_d, hi_d = np.percentile(post_ds[name] - truths2[name], [16, 84])\n",
-        "    lo_e, hi_e = np.percentile(post_ent[name] - truths2[name], [16, 84])\n",
-        "    print(f\"{name} (68% interval, offset from truth):\")\n",
-        "    print(f\"  discovery  = [{lo_d:+.3e}, {hi_d:+.3e}]\")\n",
-        "    print(f\"  enterprise = [{lo_e:+.3e}, {hi_e:+.3e}]\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "79a84f39",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-07-17T17:11:44.194819Z",
-          "iopub.status.busy": "2026-07-17T17:11:44.194261Z",
-          "iopub.status.idle": "2026-07-17T17:11:44.516599Z",
-          "shell.execute_reply": "2026-07-17T17:11:44.515940Z"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "fig, axes = plt.subplots(1, len(ctx2.sampled), figsize=(12, 3.2))\n",
-        "for ax, name in zip(np.atleast_1d(axes), ctx2.sampled):\n",
-        "    ax.hist(\n",
-        "        post_ds[name] - truths2[name],\n",
-        "        bins=40, density=True, alpha=0.6, label=\"Discovery/NUTS\",\n",
-        "    )\n",
-        "    ax.hist(\n",
-        "        post_ent[name] - truths2[name],\n",
-        "        bins=40, density=True, alpha=0.6, label=\"Enterprise/PTMCMC\",\n",
-        "    )\n",
-        "    ax.axvline(0.0, color=\"k\", ls=\"--\", lw=1, label=\"truth\")\n",
-        "    ax.set_xlabel(f\"{name} - truth\")\n",
-        "axes[0].legend(fontsize=8)\n",
-        "fig.tight_layout()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e77d03b9",
-      "metadata": {},
-      "source": [
-        "## Beyond this notebook\n",
-        "\n",
-        "- **Heterogeneous engines** — on pulsars mixing tempo2-native and PINT-native\n",
-        "  PTAs, engines are selected per native compatibility:\n",
-        "  `engines={\"tempo2\": \"jug\", \"pint\": \"jug\"}` (all-JAX, NUTS-capable) or\n",
-        "  `engines={\"tempo2\": \"libstempo\", \"pint\": \"pint\"}` (native engines; use the\n",
-        "  Enterprise/PTMCMC path, since NUTS needs JAX autodiff).\n",
-        "- **tempo2-native mode** — pass `tempo2_native=...` and\n",
-        "  `design_matrix_method=\"autodiff\"` for JUG's tempo2-compatible nonlinear\n",
-        "  path on real tempo2-era data (see `jug.timing` for the graph modes).\n",
-        "- **Run products as the interchange format** — everything decoded above used\n",
-        "  only the run-metadata files plus raw sampler output; ship a run directory\n",
-        "  anywhere and `load_run(...)` reproduces the physical posteriors without\n",
-        "  MetaPulsar, PTA data, or a timing engine installed."
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "pta",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a08f1973",
+   "metadata": {},
+   "source": [
+    "# Nonlinear timing with MetaPulsar\n",
+    "\n",
+    "This notebook shows the sampler-facing **nonlinear timing** (NLT) workflow end to end:\n",
+    "\n",
+    "1. build a `MetaPulsar` from par/tim files,\n",
+    "2. configure a `NonLinearTimingModel` and resolve it **for the pulsar**,\n",
+    "3. assemble a Discovery likelihood and sample it with NumPyro NUTS,\n",
+    "4. write the **NLT run metadata** and decode the chain back to physical\n",
+    "   timing parameters — without any live model objects,\n",
+    "5. repeat the analysis for a **multi-PTA binary combination** with custom\n",
+    "   priors, sampled through **both** likelihood interfaces: Discovery/NUTS and\n",
+    "   Enterprise/PTMCMC.\n",
+    "\n",
+    "Instead of holding every timing parameter fixed at its par-file value (or\n",
+    "linearizing around it), the nonlinear timing model *numerically samples* a\n",
+    "chosen subset of timing parameters inside the likelihood, while the remaining\n",
+    "linear nuisance parameters are analytically marginalized.\n",
+    "\n",
+    "**Requirements**: `jug-timing` (JAX timing engine), `discovery`, `numpyro`,\n",
+    "`enterprise-pulsar`, and `PTMCMCSampler` — all available in the MetaPulsar\n",
+    "devcontainer. The datasets are simulated with PINT, so no external data\n",
+    "releases are needed."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0076c5e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:07:58.219423Z",
+     "iopub.status.busy": "2026-07-17T17:07:58.219301Z",
+     "iopub.status.idle": "2026-07-17T17:07:58.226624Z",
+     "shell.execute_reply": "2026-07-17T17:07:58.225553Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# JAX must see this before it is first imported.\n",
+    "import os\n",
+    "\n",
+    "os.environ.setdefault(\"JAX_ENABLE_X64\", \"1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c8a73ec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:07:58.228438Z",
+     "iopub.status.busy": "2026-07-17T17:07:58.228306Z",
+     "iopub.status.idle": "2026-07-17T17:08:03.330622Z",
+     "shell.execute_reply": "2026-07-17T17:08:03.329660Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import jax\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from metapulsar import create_metapulsar\n",
+    "from metapulsar.sandbox_tempo2 import configure_logging\n",
+    "from nltiming import (\n",
+    "    NonLinearTimingModel,\n",
+    "    TimingInference,\n",
+    "    WhiteningConfig,\n",
+    "    load_run,\n",
+    "    sampling,\n",
+    "    save_discovery_checkpoint,\n",
+    ")\n",
+    "\n",
+    "configure_logging(level=\"WARNING\")\n",
+    "workdir = Path(tempfile.mkdtemp(prefix=\"nlt_demo_\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c131011b",
+   "metadata": {},
+   "source": [
+    "## 1. Simulate a demo dataset\n",
+    "\n",
+    "We simulate ~150 TOAs from PINT's bundled `NGC6440E` example par file. Because\n",
+    "the TOAs are drawn from the model itself (plus white noise), we know the true\n",
+    "parameter values exactly — useful for checking the posterior at the end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6645202e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:08:03.332517Z",
+     "iopub.status.busy": "2026-07-17T17:08:03.332347Z",
+     "iopub.status.idle": "2026-07-17T17:08:10.539341Z",
+     "shell.execute_reply": "2026-07-17T17:08:10.538643Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pint.config\n",
+    "from pint.models import get_model\n",
+    "from pint.simulation import make_fake_toas_uniform\n",
+    "\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "model = get_model(pint.config.examplefile(\"NGC6440E.par\"))\n",
+    "toas = make_fake_toas_uniform(\n",
+    "    startMJD=53400,\n",
+    "    endMJD=56000,\n",
+    "    ntoas=150,\n",
+    "    model=model,\n",
+    "    obs=\"gbt\",\n",
+    "    error=1.0,  # us\n",
+    "    add_noise=True,\n",
+    ")\n",
+    "\n",
+    "par_path = workdir / \"demo.par\"\n",
+    "tim_path = workdir / \"demo.tim\"\n",
+    "par_path.write_text(model.as_parfile())\n",
+    "toas.write_TOA_file(str(tim_path), format=\"tempo2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "247d1746",
+   "metadata": {},
+   "source": [
+    "## 2. Build the MetaPulsar\n",
+    "\n",
+    "`create_metapulsar` takes a `file_data` mapping of PTA name → par/tim entries.\n",
+    "Here we use a single \"PTA\"; a real multi-PTA combination simply adds more\n",
+    "entries (EPTA, PPTA, NANOGrav, …) to the same dictionary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14be1bab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:08:10.540724Z",
+     "iopub.status.busy": "2026-07-17T17:08:10.540608Z",
+     "iopub.status.idle": "2026-07-17T17:08:20.352527Z",
+     "shell.execute_reply": "2026-07-17T17:08:20.351867Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "file_data = {\n",
+    "    \"demo\": [\n",
+    "        {\"par\": str(par_path), \"tim\": str(tim_path), \"timing_package\": \"pint\"}\n",
+    "    ]\n",
+    "}\n",
+    "mp = create_metapulsar(file_data, use_pulse_numbers=\"no\")\n",
+    "\n",
+    "print(f\"pulsar:  {mp.name}\")\n",
+    "print(f\"TOAs:    {len(mp.toas)}\")\n",
+    "print(f\"fitpars: {list(mp.fitpars)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b30ef2a6",
+   "metadata": {},
+   "source": [
+    "## 3. Configure the nonlinear timing model\n",
+    "\n",
+    "Configuration is a **typed inference plan**: you name what is *marginalized*, and\n",
+    "every other timing axis is sampled. To sample just `F0`/`F1` we marginalize the\n",
+    "remaining (linear) nuisances as delta-flat — `TimingInference.groups(delta_flat=...)`.\n",
+    "(`TimingInference.sample_all()` samples every axis; `TimingInference.default()`\n",
+    "applies a versioned preset.) `for_pulsar()` resolves the configuration for the\n",
+    "pulsar and returns a `TimingContext`, which owns all per-pulsar queries.\n",
+    "\n",
+    "`whitening=WhiteningConfig()` selects the static posterior-whitening layer (the\n",
+    "sampler sees decorrelated coordinates); `engines=\"jug\"` uses the JAX timing\n",
+    "engine NUTS needs for autodiff. For binary pulsars you can pass priors right\n",
+    "here, e.g. `priors={\"TASC\": nlt_priors.delta_uniform(-0.5, 0.5, scale=\"PB\")}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44ab5821",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:08:20.353886Z",
+     "iopub.status.busy": "2026-07-17T17:08:20.353776Z",
+     "iopub.status.idle": "2026-07-17T17:08:22.991442Z",
+     "shell.execute_reply": "2026-07-17T17:08:22.990761Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Name what is marginalized; everything else is sampled. Here: sample F0/F1,\n",
+    "# marginalize the remaining linear nuisances as delta-flat.\n",
+    "nuisance = [p for p in mp.fitpars if p not in (\"F0\", \"F1\")]\n",
+    "ntm = NonLinearTimingModel(\n",
+    "    engines=\"jug\",\n",
+    "    inference=TimingInference.groups(delta_flat=nuisance),\n",
+    "    whitening=WhiteningConfig(),\n",
+    "    name=\"timing\",\n",
+    ")\n",
+    "ctx = ntm.for_pulsar(mp)\n",
+    "\n",
+    "print(f\"sampled:      {ctx.sampled}\")\n",
+    "print(f\"marginalized: {ctx.marginalized}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71aafbfb",
+   "metadata": {},
+   "source": [
+    "### Inspecting and configuring the whitening transform\n",
+    "\n",
+    "The conditioned context carries its **metric provenance** and **transport\n",
+    "record**. Whitening is configured with the frozen `WhiteningConfig` dataclass\n",
+    "(`reference_noise`, `expansion_point`, `origin`) — never a stringly-typed dict.\n",
+    "The metric uses the exact prior curvature in the prior-normal coordinate `z`\n",
+    "produced by the **probability integral transform (PIT)** — under that map the\n",
+    "timing prior is exactly `z ~ Normal(0, I)`, so the posterior precision is\n",
+    "`F_z + I`. For an assembled-likelihood run, use the two-stage lifecycle: build an\n",
+    "unconditioned base with `for_pulsar(..., condition=False)`, then finalize it\n",
+    "once with `base.with_transport(metric)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e89f7fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# whitening=WhiteningConfig() builds the *posterior* metric C C^T = (F_z + I)^-1\n",
+    "# (the +I is the exact prior curvature in the PIT / prior-normal z coordinate),\n",
+    "# so the sampler sees a locally unit-covariance target. The metric provenance\n",
+    "# and the transport record travel with the conditioned context:\n",
+    "print(f\"transport:     {ctx.transport.kind}  (latent_decodable={ctx.transport.latent_decodable})\")\n",
+    "print(f\"metric source: {ctx.metric.source!r}  (approximate={ctx.metric.approximate})\")\n",
+    "\n",
+    "# WhiteningConfig controls how the affine layer (C, c) is built. `origin` sets\n",
+    "# where x = 0 maps (the center c):\n",
+    "#   \"reference\"       -> the par-file reference z_e  (deterministic; best for repro)\n",
+    "#   \"local_posterior\" -> a guarded local-MAP Newton step (needs a metric score)\n",
+    "#   \"auto\" (default)  -> local_posterior when a score is available, else reference\n",
+    "ntm_ref = NonLinearTimingModel(\n",
+    "    engines=\"jug\",\n",
+    "    inference=TimingInference.groups(delta_flat=nuisance),\n",
+    "    name=\"timing\",\n",
+    "    whitening=WhiteningConfig(reference_noise=\"toa_errors\", origin=\"reference\"),\n",
+    ")\n",
+    "print(f\"origin policy: {ntm_ref.for_pulsar(mp).transport.origin!r}\")\n",
+    "\n",
+    "# Two-stage lifecycle: an assembled likelihood interface can hand the context\n",
+    "# its own precision instead of the toa_errors default. The unconditioned base\n",
+    "# answers every pulsar-bound query; with_transport(metric) finalizes it once.\n",
+    "base = ntm.for_pulsar(mp, condition=False)      # base.transport is None\n",
+    "conditioned = base.with_transport(base.default_metric())\n",
+    "print(f\"unconditioned -> conditioned: {base.conditioned} -> {conditioned.conditioned}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abe81094",
+   "metadata": {},
+   "source": [
+    "## 4. Discovery likelihood and NUTS sampling\n",
+    "\n",
+    "`ctx.discovery_signals()` returns Discovery-native signal objects (an\n",
+    "improper GP for the marginalized block plus a JAX nonlinear delay) that splat\n",
+    "directly into `PulsarLikelihood` — no changes to Discovery required.\n",
+    "\n",
+    "`sampling.numpyro.model` builds the standard NumPyro model (timing parameters\n",
+    "enter through one joint sample site with the physical prior attached), and\n",
+    "`sampling.numpyro.nuts` returns a configured `MCMC` with float64 enforced and\n",
+    "the chain initialized at the par-file reference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5931c1b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:08:22.992766Z",
+     "iopub.status.busy": "2026-07-17T17:08:22.992650Z",
+     "iopub.status.idle": "2026-07-17T17:08:27.272486Z",
+     "shell.execute_reply": "2026-07-17T17:08:27.271735Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import discovery as ds\n",
+    "\n",
+    "noisedict = {f\"{mp.name}_efac\": 1.0, f\"{mp.name}_log10_t2equad\": -8.0}\n",
+    "\n",
+    "likelihood = ds.PulsarLikelihood(\n",
+    "    [\n",
+    "        mp.residuals,\n",
+    "        ds.makenoise_measurement_simple(mp, noisedict),\n",
+    "        *ctx.discovery_signals(),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "nlt_model = sampling.numpyro.model(likelihood, ctx, fixed=noisedict)\n",
+    "mcmc = sampling.numpyro.nuts(nlt_model, ctx, num_warmup=500, num_samples=1000)\n",
+    "mcmc.run(jax.random.PRNGKey(0))\n",
+    "\n",
+    "x = sampling.numpyro.timing_draws(mcmc.get_samples(), ctx)\n",
+    "print(f\"latent draws: {x.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c69bccb8",
+   "metadata": {},
+   "source": [
+    "## 5. Run products: persist and decode without a live model\n",
+    "\n",
+    "`ctx.write(...)` snapshots everything needed to interpret the chain — the\n",
+    "serialized parameter space, units, digests — into small run metadata\n",
+    "(`nlt_run_meta.json` + `nlt_parameter_space.{json,npz}`). Later (or on another\n",
+    "machine), `load_run(...)` (which returns a `RunResults`) decodes the raw chain\n",
+    "into physical timing parameters from those files alone: no MetaPulsar, PTA\n",
+    "data, or timing engine required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a69469c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:08:27.274037Z",
+     "iopub.status.busy": "2026-07-17T17:08:27.273734Z",
+     "iopub.status.idle": "2026-07-17T17:08:27.338456Z",
+     "shell.execute_reply": "2026-07-17T17:08:27.337761Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "outdir = workdir / \"run\"\n",
+    "manifest = ctx.write(\n",
+    "    outdir,\n",
+    "    likelihood=\"discovery\",\n",
+    "    sampler=\"numpyro-nuts\",\n",
+    "    latent={\"kind\": \"npz\", \"path\": \"discovery_x.npz\", \"key_name\": \"x\"},\n",
+    ")\n",
+    "save_discovery_checkpoint(outdir, x, manifest, final=True)\n",
+    "\n",
+    "results = load_run(outdir)\n",
+    "post = results.posterior(units=\"display\")\n",
+    "truths = results.truths()\n",
+    "\n",
+    "for name in ctx.sampled:\n",
+    "    lo, hi = np.percentile(post[name], [16, 84])\n",
+    "    print(f\"{name}: truth = {truths[name]:.12g}   68% interval = [{lo:.12g}, {hi:.12g}]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a818c42",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:08:27.339725Z",
+     "iopub.status.busy": "2026-07-17T17:08:27.339610Z",
+     "iopub.status.idle": "2026-07-17T17:08:27.543512Z",
+     "shell.execute_reply": "2026-07-17T17:08:27.542780Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, len(ctx.sampled), figsize=(10, 3.2))\n",
+    "for ax, name in zip(np.atleast_1d(axes), ctx.sampled):\n",
+    "    ax.hist(post[name], bins=40, density=True, alpha=0.7)\n",
+    "    ax.axvline(truths[name], color=\"k\", ls=\"--\", lw=1, label=\"truth\")\n",
+    "    ax.set_xlabel(name)\n",
+    "    ax.legend()\n",
+    "fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa08e48e",
+   "metadata": {},
+   "source": [
+    "## 6. Multi-PTA combination with a binary pulsar\n",
+    "\n",
+    "The same API scales to the real use case: several PTAs observing one (binary)\n",
+    "pulsar. We simulate two overlapping datasets from an ELL1 binary par file and\n",
+    "combine them into a single pulsar — each PTA contributes its own dataset (and\n",
+    "per-PTA phase offset), while the shared timing parameters are merged across\n",
+    "PTAs.\n",
+    "\n",
+    "Two things to note in the configuration below:\n",
+    "\n",
+    "- **Base-name selectors**: both the `TimingInference` groups and the `priors`\n",
+    "  keys match by base name — `\"PB\"` / `\"TASC\"` select those parameters however\n",
+    "  they are spelled on the combined pulsar (including PTA-suffixed variants under\n",
+    "  the `per_pta` strategy). Here we sample the binary parameters `PB`/`A1`/`TASC`\n",
+    "  and marginalize the rest.\n",
+    "- `priors=` with the spec helpers from `nltiming.priors`:\n",
+    "  `delta_uniform(-0.5, 0.5, scale=\"PB\")` puts a uniform prior on the `TASC`\n",
+    "  *offset* of ± half an orbital period — the bounds are multiplied by the PB\n",
+    "  reference when resolved for the pulsar (suffix-consistently under `per_pta`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "471aa283",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:08:27.544904Z",
+     "iopub.status.busy": "2026-07-17T17:08:27.544784Z",
+     "iopub.status.idle": "2026-07-17T17:08:29.626308Z",
+     "shell.execute_reply": "2026-07-17T17:08:29.625694Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "BINARY_PAR = \"\"\"\\\n",
+    "PSRJ           J1234+4500\n",
+    "RAJ            12:34:00.0        1\n",
+    "DECJ           45:00:00.0        1\n",
+    "PMRA           0.0\n",
+    "PMDEC          0.0\n",
+    "F0             200.0             1\n",
+    "F1             -1.0e-15          1\n",
+    "PEPOCH         55000\n",
+    "POSEPOCH       55000\n",
+    "DMEPOCH        55000\n",
+    "DM             15.0              1\n",
+    "BINARY         ELL1\n",
+    "PB             12.3              1\n",
+    "A1             8.5               1\n",
+    "TASC           55000.1           1\n",
+    "EPS1           1.0e-6            1\n",
+    "EPS2           -2.0e-6           1\n",
+    "EPHEM          DE440\n",
+    "CLK            TT(BIPM2019)\n",
+    "UNITS          TDB\n",
+    "\"\"\"\n",
+    "\n",
+    "binary_par = workdir / \"binary.par\"\n",
+    "binary_par.write_text(BINARY_PAR)\n",
+    "binary_model = get_model(str(binary_par))\n",
+    "\n",
+    "np.random.seed(1)\n",
+    "spans = {\"pta_a\": (53000, 56500, \"gbt\"), \"pta_b\": (55000, 58000, \"parkes\")}\n",
+    "file_data2 = {}\n",
+    "for pta, (start, end, obs) in spans.items():\n",
+    "    fake = make_fake_toas_uniform(\n",
+    "        startMJD=start, endMJD=end, ntoas=120, model=binary_model, obs=obs,\n",
+    "        error=1.0, add_noise=True,\n",
+    "    )\n",
+    "    tim = workdir / f\"{pta}.tim\"\n",
+    "    fake.write_TOA_file(str(tim), format=\"tempo2\")\n",
+    "    file_data2[pta] = [\n",
+    "        {\"par\": str(binary_par), \"tim\": str(tim), \"timing_package\": \"pint\"}\n",
+    "    ]\n",
+    "\n",
+    "mp2 = create_metapulsar(file_data2, use_pulse_numbers=\"no\")\n",
+    "print(f\"pulsar:  {mp2.name}   TOAs: {len(mp2.toas)}  (2 PTAs)\")\n",
+    "print(f\"fitpars: {list(mp2.fitpars)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38d5eb28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:08:29.627712Z",
+     "iopub.status.busy": "2026-07-17T17:08:29.627587Z",
+     "iopub.status.idle": "2026-07-17T17:08:30.639613Z",
+     "shell.execute_reply": "2026-07-17T17:08:30.638918Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from nltiming import priors as nlt_priors\n",
+    "\n",
+    "# Sample the binary parameters; marginalize everything else (delta-flat).\n",
+    "binary = [\"PB\", \"A1\", \"TASC\"]\n",
+    "nuisance2 = [p for p in mp2.fitpars if p not in binary]\n",
+    "ntm2 = NonLinearTimingModel(\n",
+    "    engines=\"jug\",\n",
+    "    inference=TimingInference.groups(delta_flat=nuisance2),\n",
+    "    priors={\"TASC\": nlt_priors.delta_uniform(-0.5, 0.5, scale=\"PB\")},\n",
+    "    whitening=WhiteningConfig(),\n",
+    "    name=\"timing\",\n",
+    ")\n",
+    "ctx2 = ntm2.for_pulsar(mp2)\n",
+    "\n",
+    "print(f\"sampled:       {ctx2.sampled}\")\n",
+    "print(f\"marginalized:  {ctx2.marginalized}\")\n",
+    "print(f\"prior sources: {ctx2.priors.sources}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b4c920a",
+   "metadata": {},
+   "source": [
+    "The Discovery + NUTS pattern is identical to the single-PTA case — the\n",
+    "multi-PTA composite engine evaluates each PTA's rows with its own engine and\n",
+    "assembles them in canonical TOA order behind the scenes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75a06a55",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:08:30.640915Z",
+     "iopub.status.busy": "2026-07-17T17:08:30.640801Z",
+     "iopub.status.idle": "2026-07-17T17:08:36.726154Z",
+     "shell.execute_reply": "2026-07-17T17:08:36.725542Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "noisedict2 = {f\"{mp2.name}_efac\": 1.0, f\"{mp2.name}_log10_t2equad\": -8.0}\n",
+    "\n",
+    "likelihood2 = ds.PulsarLikelihood(\n",
+    "    [\n",
+    "        mp2.residuals,\n",
+    "        ds.makenoise_measurement_simple(mp2, noisedict2),\n",
+    "        *ctx2.discovery_signals(),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "nlt_model2 = sampling.numpyro.model(likelihood2, ctx2, fixed=noisedict2)\n",
+    "mcmc2 = sampling.numpyro.nuts(nlt_model2, ctx2, num_warmup=500, num_samples=1000)\n",
+    "mcmc2.run(jax.random.PRNGKey(1))\n",
+    "x2 = sampling.numpyro.timing_draws(mcmc2.get_samples(), ctx2)\n",
+    "\n",
+    "ds_dir = workdir / \"run_discovery_binary\"\n",
+    "manifest2 = ctx2.write(\n",
+    "    ds_dir,\n",
+    "    likelihood=\"discovery\",\n",
+    "    sampler=\"numpyro-nuts\",\n",
+    "    latent={\"kind\": \"npz\", \"path\": \"discovery_x.npz\", \"key_name\": \"x\"},\n",
+    ")\n",
+    "save_discovery_checkpoint(ds_dir, x2, manifest2, final=True)\n",
+    "post_ds = load_run(ds_dir).posterior(units=\"display\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b20745ec",
+   "metadata": {},
+   "source": [
+    "## 7. The same context with Enterprise + PTMCMC\n",
+    "\n",
+    "`ntm.enterprise_signal()` returns an Enterprise-native signal class that\n",
+    "combines with any other Enterprise signals and resolves per pulsar, exactly\n",
+    "like stock components. The `sampling.ptmcmc` module owns the sampler-vector ↔\n",
+    "likelihood-parameter mapping for the timing coordinate layout (the whitening\n",
+    "joint site used here under `WhiteningConfig()`, or the identity-layer `z`\n",
+    "coordinate under `whitening=None`), so no hand-written `vec_to_params` is needed.\n",
+    "\n",
+    "`sampling.ptmcmc.chain_layout(...)` records which chain columns hold the\n",
+    "timing coordinates in the run metadata — `load_run(...)` then decodes\n",
+    "the raw PTMCMC `chain_1.txt` directly, with burn-in and thinning applied\n",
+    "consistently to the latent and physical views."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "535fd6ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:08:36.727625Z",
+     "iopub.status.busy": "2026-07-17T17:08:36.727507Z",
+     "iopub.status.idle": "2026-07-17T17:11:44.192774Z",
+     "shell.execute_reply": "2026-07-17T17:11:44.191941Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from enterprise.signals import parameter, signal_base, white_signals\n",
+    "\n",
+    "ef = white_signals.MeasurementNoise(efac=parameter.Constant(1.0))\n",
+    "ent_model = ef + ntm2.enterprise_signal()\n",
+    "pta = signal_base.PTA([ent_model(mp2)])\n",
+    "print(f\"pta params: {pta.param_names}\")\n",
+    "\n",
+    "ent_dir = workdir / \"run_enterprise_binary\"\n",
+    "pts = sampling.ptmcmc.timing_only_sampler(pta, ctx2, ent_dir, verbose=False)\n",
+    "pts.sample(\n",
+    "    p0=sampling.ptmcmc.initial_point(ctx2),\n",
+    "    Niter=20000,\n",
+    "    burn=2000,\n",
+    "    thin=1,\n",
+    ")\n",
+    "\n",
+    "layout = sampling.ptmcmc.chain_layout(ctx2, pta.param_names)\n",
+    "ctx2.write(ent_dir, likelihood=\"enterprise\", sampler=\"ptmcmc\", chain_layout=layout)\n",
+    "\n",
+    "post_ent = load_run(ent_dir).posterior(burn=0.25, units=\"display\")\n",
+    "truths2 = load_run(ent_dir).truths()\n",
+    "\n",
+    "for name in ctx2.sampled:\n",
+    "    lo_d, hi_d = np.percentile(post_ds[name] - truths2[name], [16, 84])\n",
+    "    lo_e, hi_e = np.percentile(post_ent[name] - truths2[name], [16, 84])\n",
+    "    print(f\"{name} (68% interval, offset from truth):\")\n",
+    "    print(f\"  discovery  = [{lo_d:+.3e}, {hi_d:+.3e}]\")\n",
+    "    print(f\"  enterprise = [{lo_e:+.3e}, {hi_e:+.3e}]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79a84f39",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T17:11:44.194819Z",
+     "iopub.status.busy": "2026-07-17T17:11:44.194261Z",
+     "iopub.status.idle": "2026-07-17T17:11:44.516599Z",
+     "shell.execute_reply": "2026-07-17T17:11:44.515940Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, len(ctx2.sampled), figsize=(12, 3.2))\n",
+    "for ax, name in zip(np.atleast_1d(axes), ctx2.sampled):\n",
+    "    ax.hist(\n",
+    "        post_ds[name] - truths2[name],\n",
+    "        bins=40, density=True, alpha=0.6, label=\"Discovery/NUTS\",\n",
+    "    )\n",
+    "    ax.hist(\n",
+    "        post_ent[name] - truths2[name],\n",
+    "        bins=40, density=True, alpha=0.6, label=\"Enterprise/PTMCMC\",\n",
+    "    )\n",
+    "    ax.axvline(0.0, color=\"k\", ls=\"--\", lw=1, label=\"truth\")\n",
+    "    ax.set_xlabel(f\"{name} - truth\")\n",
+    "axes[0].legend(fontsize=8)\n",
+    "fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e77d03b9",
+   "metadata": {},
+   "source": [
+    "## Beyond this notebook\n",
+    "\n",
+    "- **Heterogeneous engines** — on pulsars mixing tempo2-native and PINT-native\n",
+    "  PTAs, engines are selected per native compatibility:\n",
+    "  `engines={\"tempo2\": \"jug\", \"pint\": \"jug\"}` (all-JAX, NUTS-capable) or\n",
+    "  `engines={\"tempo2\": \"libstempo\", \"pint\": \"pint\"}` (native engines; use the\n",
+    "  Enterprise/PTMCMC path, since NUTS needs JAX autodiff).\n",
+    "- **tempo2-native mode** — pass `tempo2_native=...` and\n",
+    "  `derivative_method=\"autodiff\"` for JUG's tempo2-compatible nonlinear\n",
+    "  path on real tempo2-era data (see `jug.timing` for the graph modes).\n",
+    "- **Run products as the interchange format** — everything decoded above used\n",
+    "  only the run-metadata files plus raw sampler output; ship a run directory\n",
+    "  anywhere and `load_run(...)` reproduces the physical posteriors without\n",
+    "  MetaPulsar, PTA data, or a timing engine installed.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pta",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/src/metapulsar/__init__.py
+++ b/src/metapulsar/__init__.py
@@ -47,6 +47,7 @@ from .mockpulsar import (
     create_mock_flags,
     validate_mock_data,
 )
+from .position_helpers import discover_pulsars_by_position
 from .tim_file_analyzer import TimFileAnalyzer, TimMetadata
 from .selection_utils import create_staggered_selection
 
@@ -133,6 +134,7 @@ __all__ = [
     "pta_summary",
     "get_pulsar_names_from_file_data",
     "filter_file_data_by_pulsars",
+    "discover_pulsars_by_position",
     # Nonlinear timing (lazy; see nltiming)
     "NonLinearTimingModel",
     "ParameterSpace",

--- a/src/metapulsar/file_discovery.py
+++ b/src/metapulsar/file_discovery.py
@@ -452,13 +452,13 @@ def get_pulsar_names_from_file_data(
     file_data: Dict[str, List[Dict[str, Any]]],
 ) -> List[str]:
     """
-    Extract canonical pulsar names from file data using coordinate-based discovery.
+    Extract catalog pulsar names from file data using position-based discovery.
 
     Args:
         file_data: File data from FileDiscovery (per data release)
 
     Returns:
-        List of canonical J-names (e.g., ['J0613-0200', 'J1857+0943'])
+        List of B-preferred catalog names (e.g. ['J0613-0200', 'B1855+09'])
 
     Raises:
         ValueError: If no valid pulsar files found
@@ -480,12 +480,12 @@ def filter_file_data_by_pulsars(
     """
     Filter file data to include only specified pulsars.
 
-    Supports both J-names (J1857+0943) and B-names (B1855+09) and handles
-    the conversion between them using coordinate-based matching.
+    Accepts catalog names (PSRJ/PSR/PSRB) and path-derived aliases from par/tim
+    filenames. Truncated coordinate designators are not registered.
 
     Args:
         file_data: File data from FileDiscovery (per data release)
-        pulsar_names: Single pulsar name or list of pulsar names (J or B format)
+        pulsar_names: Single pulsar name or list of catalog/path aliases
 
     Returns:
         Filtered file data containing only the specified pulsars
@@ -494,65 +494,36 @@ def filter_file_data_by_pulsars(
         ValueError: If no matching pulsars found
     """
     from .metapulsar_factory import MetaPulsarFactory
-    from .position_helpers import (
-        bj_name_from_coordinates_optimized,
-        extract_coordinates_from_parfile_optimized,
-    )
+    from .position_helpers import build_alias_map
 
     # Normalize input to list
     if isinstance(pulsar_names, str):
         pulsar_names = [pulsar_names]
 
-    # Get all pulsars using coordinate-based discovery
     factory = MetaPulsarFactory()
     pulsar_groups = factory.group_files_by_pulsar(file_data)
 
     if not pulsar_groups:
         raise ValueError("No valid pulsar files found in file_data")
 
-    # Create mapping from both J and B names to the canonical J-names
-    name_mapping = {}
-    for j_name, pta_data in pulsar_groups.items():
-        # Add J-name mapping
-        name_mapping[j_name] = j_name
+    name_mapping = build_alias_map(pulsar_groups)
 
-        # Generate B-name for this pulsar and add mapping
-        try:
-            # Get coordinates from first available file
-            coords = None
-            for pta_name, files in pta_data.items():
-                if files and "par_content" in files[0]:
-                    coords = extract_coordinates_from_parfile_optimized(
-                        files[0]["par_content"]
-                    )
-                    break
-
-            if coords:
-                ra_hours, dec_deg = coords
-                b_name = bj_name_from_coordinates_optimized(ra_hours, dec_deg, "B")
-                name_mapping[b_name] = j_name
-        except Exception:
-            # If B-name generation fails, skip it
-            pass
-
-    # Find matching canonical J-names
-    matching_j_names = []
+    matching_group_names = []
     for requested_name in pulsar_names:
         if requested_name in name_mapping:
             canonical_name = name_mapping[requested_name]
-            if canonical_name not in matching_j_names:
-                matching_j_names.append(canonical_name)
+            if canonical_name not in matching_group_names:
+                matching_group_names.append(canonical_name)
         else:
             raise ValueError(f"Pulsar '{requested_name}' not found in file data")
 
-    if not matching_j_names:
+    if not matching_group_names:
         raise ValueError(f"No matching pulsars found for: {pulsar_names}")
 
-    # Filter file data to only include matching pulsars
     filtered_file_data = {}
-    for j_name in matching_j_names:
-        if j_name in pulsar_groups:
-            for pta_name, files in pulsar_groups[j_name].items():
+    for group_name in matching_group_names:
+        if group_name in pulsar_groups:
+            for pta_name, files in pulsar_groups[group_name].items():
                 if pta_name not in filtered_file_data:
                     filtered_file_data[pta_name] = []
                 filtered_file_data[pta_name].extend(files)

--- a/src/metapulsar/metapulsar.py
+++ b/src/metapulsar/metapulsar.py
@@ -21,7 +21,14 @@ from pint.toa import TOAs
 
 # Import our supporting infrastructure
 from .parameter_manager import ParameterInconsistencyError, ParameterManager
-from .position_helpers import bj_name_from_pulsar
+from .position_helpers import (
+    assert_catalog_suffixes_compatible,
+    bj_name_from_pulsar,
+    positions_within_tolerance,
+    preferred_group_name,
+    _skycoord_from_pint_model,
+    _skycoord_from_libstempo,
+)
 
 
 @dataclass(frozen=True)
@@ -254,26 +261,32 @@ class MetaPulsar:
         return pint_models, pint_toas, lt_pulsars
 
     def _validate_pulsar_consistency(self, pint_models, lt_pulsars):
-        """Validate single pulsar across all PTAs using standardized J-names."""
-        pulsar_names = []
+        """Validate single pulsar across all PTAs by sky position and catalog suffixes."""
+        sky_coords = []
 
-        # Extract standardized J-names from PINT models
         for m in pint_models.values():
-            j_name = bj_name_from_pulsar(m, "J")
-            pulsar_names.append(j_name)
+            sky_coords.append(_skycoord_from_pint_model(m))
 
-        # Extract standardized J-names from libstempo pulsars
         for psr in lt_pulsars.values():
-            j_name = bj_name_from_pulsar(psr, "J")
-            pulsar_names.append(j_name)
+            sky_coords.append(_skycoord_from_libstempo(psr))
 
-        if not pulsar_names:
+        if not sky_coords:
             raise ValueError("No valid pulsars found for validation")
 
-        if not self._all_equal(pulsar_names):
-            raise ValueError(f"Not all the same pulsar: {pulsar_names}")
+        if not positions_within_tolerance(sky_coords, match_tol_arcsec=10.0):
+            raise ValueError(
+                "Not all PTAs refer to the same sky position within 10″ tolerance"
+            )
 
-        return pulsar_names[0]
+        catalog_names = []
+        for m in pint_models.values():
+            catalog_names.append(m.PSR.value)
+        for psr in lt_pulsars.values():
+            catalog_names.append(psr.name)
+
+        assert_catalog_suffixes_compatible(catalog_names)
+
+        return preferred_group_name(catalog_names)
 
     def _all_equal(self, iterable):
         """Check if all items in iterable are equal."""
@@ -794,24 +807,9 @@ class MetaPulsar:
         return parfile_dicts
 
     def _get_pulsar_name(self, pulsars):
-        """Get canonical pulsar name with B-name preference logic.
-
-        Returns B-name if any PTA uses B-names internally, otherwise J-name.
-        Matching is always done on J-name for coordinate-based identification.
-        """
-        from .position_helpers import bj_name_from_pulsar
-
-        # Extract all pulsar names to check for B-name usage
+        """Return B-preferred catalog name from parfile PSR fields across PTAs."""
         pulsar_names = self._extract_pulsar_names(pulsars)
-
-        # Use first pulsar for coordinate-based name generation
-        first_pulsar = next(iter(pulsars.values()))
-
-        # Check if any PTA uses B-names and return appropriate name
-        if any(name.startswith("B") and len(name) >= 6 for name in pulsar_names):
-            return bj_name_from_pulsar(first_pulsar, "B")
-        else:
-            return bj_name_from_pulsar(first_pulsar, "J")
+        return preferred_group_name(pulsar_names)
 
     def _extract_pulsar_names(self, pulsars):
         """Extract all pulsar names from PTA objects.

--- a/src/metapulsar/metapulsar_factory.py
+++ b/src/metapulsar/metapulsar_factory.py
@@ -23,7 +23,7 @@ except ImportError:
 # Import MetaPulsar and ParameterManager
 from .metapulsar import MetaPulsar, normalize_combination_strategy
 from .parameter_manager import ParameterManager
-from .position_helpers import discover_pulsars_by_coordinates_optimized
+from .position_helpers import discover_pulsars_by_position
 
 # Import PINT for model creation
 try:
@@ -301,7 +301,7 @@ class MetaPulsarFactory:
             )
 
         # 4. Get pulsar name for output filename generation
-        pulsar_groups = discover_pulsars_by_coordinates_optimized(validated_data)
+        pulsar_groups = discover_pulsars_by_position(validated_data)
         pulsar_name = list(pulsar_groups.keys())[0] if pulsar_groups else "unknown"
 
         # 5. Create MetaPulsar
@@ -383,7 +383,7 @@ class MetaPulsarFactory:
             ValueError: If multiple pulsars detected or no valid files found
         """
         # Group files by pulsar using coordinate-based identification
-        pulsar_groups = discover_pulsars_by_coordinates_optimized(file_data)
+        pulsar_groups = discover_pulsars_by_position(file_data)
 
         if not pulsar_groups:
             raise ValueError("No valid pulsar files found in file_data")
@@ -404,7 +404,7 @@ class MetaPulsarFactory:
     def group_files_by_pulsar(
         self, file_data: Dict[str, List[Dict[str, Any]]]
     ) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
-        """Group file data by pulsar using coordinate-based identification.
+        """Group file data by pulsar using J2000 position matching and catalog names.
 
         This utility function takes multi-pulsar file data and groups it by pulsar,
         making it suitable for creating individual MetaPulsars.
@@ -429,10 +429,10 @@ class MetaPulsarFactory:
             ValueError: If no valid pulsar files found
         """
         self.logger.info(
-            "Grouping files by pulsar using coordinate-based identification"
+            "Grouping files by pulsar using position-based catalog identification"
         )
 
-        pulsar_groups = discover_pulsars_by_coordinates_optimized(file_data)
+        pulsar_groups = discover_pulsars_by_position(file_data)
 
         if not pulsar_groups:
             raise ValueError("No valid pulsar files found in file_data")
@@ -462,7 +462,7 @@ class MetaPulsarFactory:
             }
         """
         # First, group by pulsar using coordinate-based identification
-        pulsar_groups = discover_pulsars_by_coordinates_optimized(file_data)
+        pulsar_groups = discover_pulsars_by_position(file_data)
 
         if not pulsar_groups:
             raise ValueError("No valid pulsar files found in file_data")
@@ -626,50 +626,8 @@ class MetaPulsarFactory:
     def _get_display_name_for_pulsar(
         self, pulsar_name: str, pulsar_file_data: Dict[str, List[Dict[str, Any]]]
     ) -> str:
-        """Get display name for pulsar using B-name preference logic.
-
-        Returns B-name if any PTA uses B-names internally, otherwise J-name.
-        This matches the naming logic used in MetaPulsar.
-
-        Args:
-            pulsar_name: J-name from coordinate-based discovery
-            pulsar_file_data: File data for this pulsar
-
-        Returns:
-            Display name (B-name or J-name)
-        """
-        # Check if any PTA uses B-names internally
-        if self._any_pta_uses_b_names(pulsar_file_data):
-            # Extract coordinates from first file and convert to B-name
-            from .position_helpers import (
-                extract_coordinates_from_parfile_optimized,
-                bj_name_from_coordinates_optimized,
-            )
-
-            first_pta = list(pulsar_file_data.keys())[0]
-            first_file = pulsar_file_data[first_pta][0]
-            coords = extract_coordinates_from_parfile_optimized(
-                first_file["par_content"]
-            )
-
-            if coords:
-                return bj_name_from_coordinates_optimized(coords[0], coords[1], "B")
-
+        """Return catalog display name (group key from position-based discovery)."""
         return pulsar_name
-
-    def _any_pta_uses_b_names(
-        self, pulsar_file_data: Dict[str, List[Dict[str, Any]]]
-    ) -> bool:
-        """Check if any PTA uses B-names internally."""
-        for pta_name, files in pulsar_file_data.items():
-            for file_info in files:
-                from .pint_helpers import create_pint_model
-
-                model = create_pint_model(file_info["par_content"])
-                pta_pulsar_name = model.PSR.value
-                if pta_pulsar_name.startswith("B") and len(pta_pulsar_name) >= 6:
-                    return True
-        return False
 
     def pta_summary(self, file_data: Dict[str, List[Dict[str, Any]]]) -> None:
         """Display summary statistics for all pulsars and PTAs in the file data.

--- a/src/metapulsar/position_helpers.py
+++ b/src/metapulsar/position_helpers.py
@@ -14,7 +14,9 @@ Functions:
     _format_b_name_from_icrs: Format ICRS coordinates into B-name string
 """
 
-from typing import Any, Dict, Optional, Tuple, List
+from typing import Any, Dict, Optional, Tuple, List, Iterable, Set
+import re
+import warnings
 import numpy as np
 from astropy.coordinates import (
     SkyCoord,
@@ -421,6 +423,349 @@ def _get_pulsar_name_from_parfile_dict(parfile_dict: Dict[str, str]) -> str:
     return "<unknown>"
 
 
+_CATALOG_NAME_RE = re.compile(r"^([BJ]\d{4}[+-]\d{2,4})([A-Z])?$")
+
+
+def parse_catalog_names(parfile_content: str) -> Dict[str, Optional[str]]:
+    """Parse PSRJ / PSRB / PSR fields from parfile content."""
+    parfile_dict = _parse_parfile_optimized(parfile_content)
+    result: Dict[str, Optional[str]] = {"psrj": None, "psrb": None, "psr": None}
+    for key, out_key in (("PSRJ", "psrj"), ("PSRB", "psrb"), ("PSR", "psr")):
+        val = parfile_dict.get(key)
+        if val:
+            result[out_key] = val.strip()
+    return result
+
+
+def catalog_name_candidates(parfile_dict: Dict[str, str]) -> List[str]:
+    """Ordered unique catalog strings present on a parfile."""
+    seen: Set[str] = set()
+    out: List[str] = []
+    for key in ("PSRJ", "PSRB", "PSR"):
+        val = parfile_dict.get(key)
+        if val:
+            name = val.strip()
+            if name and name not in seen:
+                seen.add(name)
+                out.append(name)
+    return out
+
+
+def letter_suffix(name: str) -> Optional[str]:
+    """Trailing cluster letter (A–Z) after the numeric designator, if any."""
+    m = _CATALOG_NAME_RE.match(name.strip())
+    if not m:
+        return None
+    return m.group(2)
+
+
+def preferred_file_label(parfile_dict: Dict[str, str], path_name: Optional[str]) -> str:
+    """B-preferred catalog label for one file; path_name is last resort."""
+    psrj = (parfile_dict.get("PSRJ") or "").strip() or None
+    psrb = (parfile_dict.get("PSRB") or "").strip() or None
+    psr = (parfile_dict.get("PSR") or "").strip() or None
+
+    if psrb:
+        return psrb
+    if psr and psr.startswith("B") and len(psr) >= 6:
+        return psr
+    if psrj:
+        return psrj
+    if psr:
+        return psr
+    if path_name:
+        logger.warning(
+            f"No PSRJ/PSRB/PSR in parfile; using path name {path_name!r} as label"
+        )
+        return path_name
+    return "<unknown>"
+
+
+def preferred_group_name(catalog_strings: Iterable[str]) -> str:
+    """B-preferred display name for a pulsar group from all member catalog strings."""
+    names = [n.strip() for n in catalog_strings if n and n.strip()]
+    if not names:
+        raise ValueError("Cannot determine group name: no catalog strings")
+
+    b_names = sorted({n for n in names if n.startswith("B") and len(n) >= 6})
+    if b_names:
+        return b_names[0]
+
+    j_names = sorted({n for n in names if n.startswith("J")})
+    if j_names:
+        suffixed = sorted(n for n in j_names if letter_suffix(n))
+        if suffixed:
+            return suffixed[0]
+        return j_names[0]
+
+    return sorted(set(names))[0]
+
+
+def _suffix_sets_compatible(
+    suffixes_a: Set[Optional[str]], suffixes_b: Set[Optional[str]]
+) -> Tuple[bool, Optional[str], bool]:
+    """Compare suffix sets for two clusters. Returns (may_merge, error, warn_separate)."""
+    combined = suffixes_a | suffixes_b
+    non_null = {s for s in combined if s is not None}
+    has_null = None in combined
+
+    if non_null and has_null and len(non_null) > 0:
+        return (
+            False,
+            f"Ambiguous pulsar identity: mixed letter suffix and bare catalog names "
+            f"(suffixes={non_null}) within match tolerance",
+            False,
+        )
+    if len(non_null) > 1:
+        return False, None, True
+    return True, None, False
+
+
+def _collect_suffixes_from_catalogs(catalogs: Iterable[str]) -> Set[Optional[str]]:
+    out: Set[Optional[str]] = set()
+    for name in catalogs:
+        out.add(letter_suffix(name))
+    if not out:
+        out.add(None)
+    return out
+
+
+class _UnionFind:
+    def __init__(self, n: int) -> None:
+        self.parent = list(range(n))
+
+    def find(self, x: int) -> int:
+        while self.parent[x] != x:
+            self.parent[x] = self.parent[self.parent[x]]
+            x = self.parent[x]
+        return x
+
+    def union(self, a: int, b: int) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            self.parent[rb] = ra
+
+
+def _build_position_records(
+    file_data: Dict[str, List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """One record per file with sky position and catalog metadata."""
+    from pathlib import Path
+
+    from .file_discovery import extract_pulsar_name_from_path
+
+    records: List[Dict[str, Any]] = []
+    for pta_name, file_list in file_data.items():
+        for file_dict in file_list:
+            par_content = file_dict.get("par_content")
+            if not par_content:
+                logger.warning(
+                    f"Skipping file without par_content: {file_dict.get('par', 'unknown')}"
+                )
+                continue
+
+            coords = extract_coordinates_from_parfile_optimized(par_content)
+            if coords is None:
+                logger.warning(
+                    f"Could not extract coordinates from {file_dict.get('par', 'unknown')}"
+                )
+                continue
+
+            ra_hours, dec_deg = coords
+            parfile_dict = _parse_parfile_optimized(par_content)
+            path_name: Optional[str] = None
+            par_path = file_dict.get("par")
+            if par_path is not None:
+                try:
+                    path_name = extract_pulsar_name_from_path(Path(par_path))
+                except ValueError:
+                    path_name = None
+
+            catalogs = catalog_name_candidates(parfile_dict)
+            if path_name and path_name not in catalogs:
+                catalogs = catalogs + [path_name]
+
+            file_label = preferred_file_label(parfile_dict, path_name)
+            skycoord = SkyCoord(
+                ra=ra_hours * u.hourangle, dec=dec_deg * u.deg, frame=ICRS()
+            )
+
+            records.append(
+                {
+                    "pta_name": pta_name,
+                    "file_dict": file_dict,
+                    "skycoord": skycoord,
+                    "catalogs": catalogs,
+                    "file_label": file_label,
+                    "suffixes": _collect_suffixes_from_catalogs(catalogs),
+                }
+            )
+
+            file_dict["catalog_names"] = list(catalog_name_candidates(parfile_dict))
+            file_dict["path_name"] = path_name
+            file_dict["file_label"] = file_label
+
+    return records
+
+
+def _cluster_records_by_position(
+    records: List[Dict[str, Any]], match_tol_arcsec: float
+) -> List[List[int]]:
+    """Cluster record indices by on-sky separation and suffix rules."""
+    n = len(records)
+    if n == 0:
+        return []
+
+    tol = match_tol_arcsec * u.arcsec
+    uf = _UnionFind(n)
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            sep = records[i]["skycoord"].separation(records[j]["skycoord"])
+            if sep > tol:
+                continue
+
+            ok, err, warn_sep = _suffix_sets_compatible(
+                records[i]["suffixes"], records[j]["suffixes"]
+            )
+            if err:
+                raise ValueError(err)
+            if warn_sep:
+                warnings.warn(
+                    f"Pulsars within {match_tol_arcsec}″ have different letter suffixes "
+                    f"({records[i]['catalogs']!r} vs {records[j]['catalogs']!r}); "
+                    "keeping separate groups",
+                    stacklevel=2,
+                )
+                continue
+            if ok:
+                uf.union(i, j)
+
+    clusters: Dict[int, List[int]] = {}
+    for idx in range(n):
+        root = uf.find(idx)
+        clusters.setdefault(root, []).append(idx)
+
+    return list(clusters.values())
+
+
+def _check_catalog_alias_position_consistency(
+    records: List[Dict[str, Any]], match_tol_arcsec: float
+) -> None:
+    """Same catalog/path alias on files separated by > tolerance → ValueError."""
+    tol = match_tol_arcsec * u.arcsec
+    alias_to_idx: Dict[str, int] = {}
+    for idx, rec in enumerate(records):
+        for alias in rec["catalogs"]:
+            if alias in alias_to_idx:
+                other = alias_to_idx[alias]
+                sep = records[other]["skycoord"].separation(rec["skycoord"])
+                if sep > tol:
+                    raise ValueError(
+                        f"Catalog name {alias!r} appears on distinct sky positions "
+                        f"(separation {sep.to(u.arcsec).value:.3f}″ > {match_tol_arcsec}″)"
+                    )
+            else:
+                alias_to_idx[alias] = idx
+
+
+def discover_pulsars_by_position(
+    file_data: Dict[str, List[Dict[str, Any]]],
+    match_tol_arcsec: float = 10.0,
+) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
+    """Group PTA file data by J2000 position (≤ match_tol) and catalog identity."""
+    records = _build_position_records(file_data)
+    if not records:
+        logger.info("Discovered 0 unique pulsars across all PTAs")
+        return {}
+
+    _check_catalog_alias_position_consistency(records, match_tol_arcsec)
+    cluster_lists = _cluster_records_by_position(records, match_tol_arcsec)
+
+    groups: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+    for member_indices in cluster_lists:
+        all_catalogs: List[str] = []
+        for idx in member_indices:
+            all_catalogs.extend(records[idx]["catalogs"])
+
+        group_name = preferred_group_name(all_catalogs)
+        if group_name in groups:
+            raise ValueError(
+                f"Duplicate pulsar group name {group_name!r} for distinct clusters"
+            )
+
+        pta_map: Dict[str, List[Dict[str, Any]]] = {}
+        for idx in member_indices:
+            rec = records[idx]
+            pta = rec["pta_name"]
+            pta_map.setdefault(pta, []).append(rec["file_dict"])
+
+        groups[group_name] = pta_map
+        logger.debug(
+            f"Group {group_name!r}: {len(member_indices)} file(s), "
+            f"aliases={sorted(set(all_catalogs))}"
+        )
+
+    logger.info(f"Discovered {len(groups)} unique pulsars across all PTAs")
+    return groups
+
+
+def build_alias_map(
+    pulsar_groups: Dict[str, Dict[str, List[Dict[str, Any]]]],
+) -> Dict[str, str]:
+    """Map catalog and path aliases to group display names (no truncated coord names)."""
+    alias_map: Dict[str, str] = {}
+    for group_name, pta_data in pulsar_groups.items():
+        alias_map[group_name] = group_name
+        for files in pta_data.values():
+            for file_dict in files:
+                for key in ("catalog_names",):
+                    for alias in file_dict.get(key) or []:
+                        if alias in alias_map and alias_map[alias] != group_name:
+                            raise ValueError(
+                                f"Alias {alias!r} maps to both "
+                                f"{alias_map[alias]!r} and {group_name!r}"
+                            )
+                        alias_map[alias] = group_name
+                path_name = file_dict.get("path_name")
+                if path_name:
+                    if path_name in alias_map and alias_map[path_name] != group_name:
+                        raise ValueError(
+                            f"Path alias {path_name!r} maps to both "
+                            f"{alias_map[path_name]!r} and {group_name!r}"
+                        )
+                    alias_map[path_name] = group_name
+    return alias_map
+
+
+def positions_within_tolerance(
+    coords: Iterable[SkyCoord], match_tol_arcsec: float = 10.0
+) -> bool:
+    """True if all sky positions are pairwise within match_tol_arcsec."""
+    coord_list = list(coords)
+    if len(coord_list) <= 1:
+        return True
+    tol = match_tol_arcsec * u.arcsec
+    for i in range(len(coord_list)):
+        for j in range(i + 1, len(coord_list)):
+            if coord_list[i].separation(coord_list[j]) > tol:
+                return False
+    return True
+
+
+def assert_catalog_suffixes_compatible(catalog_names: Iterable[str]) -> None:
+    """Raise if letter-suffix rules forbid a single MetaPulsar."""
+    names = [n for n in catalog_names if n]
+    suffixes = {letter_suffix(n) for n in names}
+    non_null = {s for s in suffixes if s is not None}
+    if None in suffixes and non_null:
+        raise ValueError(
+            f"Inconsistent pulsar letter suffixes across PTAs: {sorted(names)}"
+        )
+    if len(non_null) > 1:
+        raise ValueError(f"Distinct letter suffixes in one MetaPulsar: {sorted(names)}")
+
+
 def _get_posepoch_mjd_optimized(parfile_dict: Dict[str, str]) -> Optional[float]:
     """Return POSEPOCH (MJD), falling back to PEPOCH when POSEPOCH is absent.
 
@@ -743,58 +1088,13 @@ def _format_b_name_from_coordinates_optimized(ra_hours: float, dec_deg: float) -
 def discover_pulsars_by_coordinates_optimized(
     file_data: Dict[str, List[Dict[str, Any]]],
 ) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
-    """
-    Discover pulsars by extracting coordinates directly from parfiles (optimized version).
+    """Deprecated alias for :func:`discover_pulsars_by_position`."""
+    import warnings
 
-    This optimized version bypasses PINT model creation and extracts
-    coordinates using lightweight parsing for significant performance improvements.
-
-    Args:
-        file_data: Dictionary mapping PTA names to file lists
-
-    Returns:
-        Dictionary mapping J-names to PTA file data
-    """
-    coordinate_map = {}
-
-    for pta_name, file_list in file_data.items():
-        logger.debug(f"Processing {len(file_list)} files for PTA {pta_name}")
-
-        for file_dict in file_list:
-            try:
-                # Extract coordinates directly from parfile content
-                coords = extract_coordinates_from_parfile_optimized(
-                    file_dict["par_content"]
-                )
-
-                if coords is None:
-                    logger.warning(
-                        f"Could not extract coordinates from {file_dict.get('par', 'unknown')}"
-                    )
-                    continue
-
-                ra_hours, dec_deg = coords
-
-                # Generate J-name directly from coordinates
-                j_name = bj_name_from_coordinates_optimized(ra_hours, dec_deg, "J")
-
-                # Add to coordinate map
-                if j_name not in coordinate_map:
-                    coordinate_map[j_name] = {}
-                if pta_name not in coordinate_map[j_name]:
-                    coordinate_map[j_name][pta_name] = []
-
-                coordinate_map[j_name][pta_name].append(file_dict)
-
-                logger.debug(
-                    f"Found pulsar {j_name} at RA={ra_hours:.4f}h, DEC={dec_deg:.4f}°"
-                )
-
-            except Exception as e:
-                logger.warning(
-                    f"Failed to process {file_dict.get('par', 'unknown')}: {e}"
-                )
-                continue
-
-    logger.info(f"Discovered {len(coordinate_map)} unique pulsars across all PTAs")
-    return coordinate_map
+    warnings.warn(
+        "discover_pulsars_by_coordinates_optimized is deprecated; "
+        "use discover_pulsars_by_position",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return discover_pulsars_by_position(file_data)

--- a/tests/test_coordinate_based_discovery.py
+++ b/tests/test_coordinate_based_discovery.py
@@ -16,6 +16,7 @@ from pint.models.model_builder import ModelBuilder
 from metapulsar.file_discovery import FileDiscovery
 from metapulsar.position_helpers import (
     bj_name_from_pulsar,
+    discover_pulsars_by_position,
     discover_pulsars_by_coordinates_optimized,
 )
 from metapulsar.metapulsar import MetaPulsar
@@ -172,69 +173,39 @@ class TestCoordinateBasedDiscovery:
         mock_file_discovery,
         mock_file_system,
     ):
-        """Test coordinate-based pulsar discovery."""
-        # Mock parse_parfile to return a dictionary
-        mock_par_dict = {
-            "PSRJ": ["J1857+0943"],
-            "RAJ": ["18:57:36.3906121"],
-            "DECJ": ["+09:43:17.20714"],
-            "F0": ["186.494081"],
+        """Test position-based pulsar discovery merges B/J catalog aliases."""
+        file_data = {
+            "test_data_release1": [
+                {
+                    "par": mock_file_system / "data1" / "J1857+0943.par",
+                    "tim": mock_file_system / "data1" / "J1857+0943.tim",
+                    "par_content": (
+                        mock_file_system / "data1" / "J1857+0943.par"
+                    ).read_text(),
+                    "timing_package": "pint",
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
+                }
+            ],
+            "test_data_release2": [
+                {
+                    "par": mock_file_system / "data2" / "B1855+09.par",
+                    "tim": mock_file_system / "data2" / "B1855+09.tim",
+                    "par_content": (
+                        mock_file_system / "data2" / "B1855+09.par"
+                    ).read_text(),
+                    "timing_package": "pint",
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
+                }
+            ],
         }
-        mock_parse_parfile.return_value = mock_par_dict
+        coordinate_map = discover_pulsars_by_position(file_data)
 
-        # Mock ModelBuilder to return a TimingModel-like object with components
-        mock_model = self._create_mock_model_with_components()
-        mock_model_builder = Mock()
-        mock_model_builder.return_value = mock_model
-        mock_model_builder_class.return_value = mock_model_builder
-
-        # Update registry with real paths
-        mock_file_discovery.data_releases["test_data_release1"]["base_dir"] = str(
-            mock_file_system / "data1"
-        )
-        mock_file_discovery.data_releases["test_data_release2"]["base_dir"] = str(
-            mock_file_system / "data2"
-        )
-
-        # factory = MetaPulsarFactory()
-
-        # Mock the coordinate extraction
-        with patch("metapulsar.position_helpers.bj_name_from_pulsar") as mock_bj_name:
-            mock_bj_name.side_effect = lambda model, name_type: (
-                "J1857+0943" if name_type == "J" else "B1855+09"
-            )
-
-            # Create file_data format expected by the method
-            file_data = {
-                "test_data_release1": [
-                    {
-                        "par": mock_file_system / "data1" / "J1857+0943.par",
-                        "tim": mock_file_system / "data1" / "J1857+0943.tim",
-                        "par_content": "PSR J1857+0943\nRAJ 18:57:36.4\nDECJ 09:43:17.1\n",
-                        "timing_package": "pint",
-                        "tim_metadata": make_tim_metadata(timespan_days=1000.0),
-                    }
-                ],
-                "test_data_release2": [
-                    {
-                        "par": mock_file_system / "data2" / "J1857+0943.par",
-                        "tim": mock_file_system / "data2" / "J1857+0943.tim",
-                        "par_content": "PSR J1857+0943\nRAJ 18:57:36.4\nDECJ 09:43:17.1\n",
-                        "timing_package": "pint",
-                        "tim_metadata": make_tim_metadata(timespan_days=1000.0),
-                    }
-                ],
-            }
-            coordinate_map = discover_pulsars_by_coordinates_optimized(file_data)
-
-            # Should find both PTAs have the same pulsar
-            assert "J1857+0943" in coordinate_map
-            pulsar_info = coordinate_map["J1857+0943"]
-            assert "test_data_release1" in pulsar_info
-            assert "test_data_release2" in pulsar_info
-            # Check that both PTAs have file data
-            assert len(pulsar_info["test_data_release1"]) > 0
-            assert len(pulsar_info["test_data_release2"]) > 0
+        assert "B1855+09" in coordinate_map
+        pulsar_info = coordinate_map["B1855+09"]
+        assert "test_data_release1" in pulsar_info
+        assert "test_data_release2" in pulsar_info
+        assert len(pulsar_info["test_data_release1"]) > 0
+        assert len(pulsar_info["test_data_release2"]) > 0
 
     def test_create_metapulsar_with_canonical_name(
         self, mock_file_discovery, mock_file_system
@@ -338,18 +309,37 @@ class TestEdgeCases:
 # === INTEGRATION TESTS ===
 
 
-def test_discover_pulsars_different_posepoch_match(load_parfile_text):
-    """Test that pulsars with correct positions at different POSEPOCH are matched correctly.
+def test_discover_pulsars_same_j2000_position_merge(load_parfile_text):
+    """Two PTAs with identical parfiles merge into one catalog-named group."""
+    parfile = load_parfile_text("test_same_pulsar_epoch1_54500.par")
 
-    Uses generated parfiles with correct positions at each epoch (reflecting proper motion),
-    which should normalize to the same J2000 position and match.
+    file_data = {
+        "PTA1": [
+            {
+                "par": "test1.par",
+                "par_content": parfile,
+                "tim": "test1.tim",
+            }
+        ],
+        "PTA2": [
+            {
+                "par": "test2.par",
+                "par_content": parfile,
+                "tim": "test2.tim",
+            }
+        ],
+    }
 
-    Note: This is an integration test for the discovery system. The unit test for normalization
-    logic is in test_position_helpers.py::test_same_pulsar_different_posepoch_produces_same_j_name
-    """
-    # Use generated parfiles with correct positions at different epochs
-    # These have different positions at different POSEPOCH but same PM,
-    # so they normalize to the same J2000 position
+    coordinate_map = discover_pulsars_by_position(file_data)
+    assert len(coordinate_map) == 1
+    group_name = next(iter(coordinate_map))
+    assert len(coordinate_map[group_name]) == 2
+
+
+def test_discover_pulsars_same_catalog_name_over_tolerance_raises(
+    load_parfile_text,
+):
+    """Same PSRJ on files with J2000 separation > match tolerance is a hard error."""
     parfile_epoch1 = load_parfile_text("test_same_pulsar_epoch1_54500.par")
     parfile_epoch2 = load_parfile_text("test_same_pulsar_epoch2_56000.par")
 
@@ -370,66 +360,5 @@ def test_discover_pulsars_different_posepoch_match(load_parfile_text):
         ],
     }
 
-    coordinate_map = discover_pulsars_by_coordinates_optimized(file_data)
-
-    # Should match as same pulsar despite different POSEPOCH
-    # (because positions are correctly different at each epoch, normalizing to same J2000)
-    assert len(coordinate_map) == 1, "Should match as single pulsar"
-    assert "J1857+0943" in coordinate_map
-    pulsar_data = coordinate_map["J1857+0943"]
-    assert len(pulsar_data) == 2, "Both PTAs should be matched"
-    assert "PTA1" in pulsar_data, "PTA1 should be in matched pulsar data"
-    assert "PTA2" in pulsar_data, "PTA2 should be in matched pulsar data"
-
-
-def test_discover_pulsars_same_position_different_posepoch_should_not_match(
-    load_parfile_text,
-):
-    """Test that parfiles with identical positions but different POSEPOCH and PM should NOT match.
-
-    This tests the error case: if someone incorrectly provides the same position at different
-    epochs when proper motion exists, they normalize to different J2000 positions and should
-    be discovered as separate pulsars.
-
-    Uses very large PM values (15000 mas/yr) for testing to ensure coordinate difference > 1 arcmin,
-    which produces different J-names and allows the discovery system to correctly separate them.
-
-    The unit test for this normalization behavior is in
-    test_position_helpers.py::test_same_position_different_posepoch_with_pm_should_not_match
-    """
-    # Use generated parfiles with same position at different POSEPOCH
-    parfile_epoch1 = load_parfile_text("test_same_position_large_pm_epoch1_54500.par")
-    parfile_epoch2 = load_parfile_text("test_same_position_large_pm_epoch2_56000.par")
-
-    # Test discovery system behavior
-    file_data = {
-        "PTA1": [
-            {
-                "par": "test1.par",
-                "par_content": parfile_epoch1,
-                "tim": "test1.tim",
-            }
-        ],
-        "PTA2": [
-            {
-                "par": "test2.par",
-                "par_content": parfile_epoch2,
-                "tim": "test2.tim",
-            }
-        ],
-    }
-
-    coordinate_map = discover_pulsars_by_coordinates_optimized(file_data)
-
-    # With large PM (15000 mas/yr), coordinate difference is > 1 arcmin,
-    # so J-names should differ and they should be discovered as separate pulsars
-    assert (
-        len(coordinate_map) == 2
-    ), "Should discover as two separate pulsars when same position at different POSEPOCH with large PM"
-
-    # Verify they have different J-names
-    j_names = list(coordinate_map.keys())
-    assert len(j_names) == 2, f"Should have two different J-names, got: {j_names}"
-    assert (
-        j_names[0] != j_names[1]
-    ), f"J-names should differ: {j_names[0]} == {j_names[1]}"
+    with pytest.raises(ValueError, match="distinct sky positions"):
+        discover_pulsars_by_position(file_data)

--- a/tests/test_file_discovery.py
+++ b/tests/test_file_discovery.py
@@ -8,6 +8,14 @@ from metapulsar import discover_files
 from tests.helpers import make_tim_metadata
 
 
+def _with_catalog_aliases(file_entry, catalog_names, path_name=None):
+    """Attach identity fields expected by build_alias_map in filter tests."""
+    enriched = dict(file_entry)
+    enriched["catalog_names"] = list(catalog_names)
+    enriched["path_name"] = path_name or catalog_names[0]
+    return enriched
+
+
 class TestFileDiscovery:
     """Test FileDiscovery functionality."""
 
@@ -481,32 +489,19 @@ class TestPulsarHelperFunctions:
             ],
         }
 
-        with (
-            patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory,
-            patch(
-                "metapulsar.position_helpers.bj_name_from_coordinates_optimized"
-            ) as mock_bj_name,
-            patch(
-                "metapulsar.position_helpers.extract_coordinates_from_parfile_optimized"
-            ) as mock_extract,
-        ):
+        epta_file = _with_catalog_aliases(file_data["epta_dr2"][0], ["J0613-0200"])
+        ppta_file = _with_catalog_aliases(file_data["ppta_dr2"][0], ["J1857+0943"])
 
+        with patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory:
             mock_instance = mock_factory.return_value
             mock_instance.group_files_by_pulsar.return_value = {
-                "J0613-0200": {"epta_dr2": [file_data["epta_dr2"][0]]},
-                "J1857+0943": {"ppta_dr2": [file_data["ppta_dr2"][0]]},
+                "J0613-0200": {"epta_dr2": [epta_file]},
+                "J1857+0943": {"ppta_dr2": [ppta_file]},
             }
-
-            # Mock coordinate extraction and B-name generation
-            mock_extract.side_effect = [
-                (1.0, 2.0),  # For J0613-0200
-                (3.0, 4.0),  # For J1857+0943
-            ]
-            mock_bj_name.side_effect = ["B0613-02", "B1857+09"]
 
             result = filter_file_data_by_pulsars(file_data, "J0613-0200")
 
-            assert result == {"epta_dr2": [file_data["epta_dr2"][0]]}
+            assert result == {"epta_dr2": [epta_file]}
 
     def test_filter_file_data_by_pulsars_multiple_j_names(self):
         """Test filtering file data by multiple J-names."""
@@ -533,36 +528,23 @@ class TestPulsarHelperFunctions:
             ],
         }
 
-        with (
-            patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory,
-            patch(
-                "metapulsar.position_helpers.bj_name_from_coordinates_optimized"
-            ) as mock_bj_name,
-            patch(
-                "metapulsar.position_helpers.extract_coordinates_from_parfile_optimized"
-            ) as mock_extract,
-        ):
+        epta_file = _with_catalog_aliases(file_data["epta_dr2"][0], ["J0613-0200"])
+        ppta_file = _with_catalog_aliases(file_data["ppta_dr2"][0], ["J1857+0943"])
 
+        with patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory:
             mock_instance = mock_factory.return_value
             mock_instance.group_files_by_pulsar.return_value = {
-                "J0613-0200": {"epta_dr2": [file_data["epta_dr2"][0]]},
-                "J1857+0943": {"ppta_dr2": [file_data["ppta_dr2"][0]]},
+                "J0613-0200": {"epta_dr2": [epta_file]},
+                "J1857+0943": {"ppta_dr2": [ppta_file]},
             }
-
-            # Mock coordinate extraction and B-name generation
-            mock_extract.side_effect = [
-                (1.0, 2.0),  # For J0613-0200
-                (3.0, 4.0),  # For J1857+0943
-            ]
-            mock_bj_name.side_effect = ["B0613-02", "B1857+09"]
 
             result = filter_file_data_by_pulsars(
                 file_data, ["J0613-0200", "J1857+0943"]
             )
 
             expected = {
-                "epta_dr2": [file_data["epta_dr2"][0]],
-                "ppta_dr2": [file_data["ppta_dr2"][0]],
+                "epta_dr2": [epta_file],
+                "ppta_dr2": [ppta_file],
             }
             assert result == expected
 
@@ -573,37 +555,26 @@ class TestPulsarHelperFunctions:
         file_data = {
             "epta_dr2": [
                 {
-                    "par": "test/J0613-0200.par",
-                    "tim": "test/J0613-0200.tim",
-                    "par_content": "PSR J0613-0200\nRAJ 06:13:43.9754\nDECJ -02:00:47.1755\n",
+                    "par": "test/B0613-02.par",
+                    "tim": "test/B0613-02.tim",
+                    "par_content": "PSR B0613-02\nRAJ 06:13:43.9754\nDECJ -02:00:47.1755\n",
                     "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                     "timing_package": "tempo2",
                 }
             ]
         }
 
-        with (
-            patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory,
-            patch(
-                "metapulsar.position_helpers.bj_name_from_coordinates_optimized"
-            ) as mock_bj_name,
-            patch(
-                "metapulsar.position_helpers.extract_coordinates_from_parfile_optimized"
-            ) as mock_extract,
-        ):
+        epta_file = _with_catalog_aliases(file_data["epta_dr2"][0], ["B0613-02"])
 
+        with patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory:
             mock_instance = mock_factory.return_value
             mock_instance.group_files_by_pulsar.return_value = {
-                "J0613-0200": {"epta_dr2": [file_data["epta_dr2"][0]]}
+                "B0613-02": {"epta_dr2": [epta_file]}
             }
-
-            # Mock coordinate extraction and B-name generation
-            mock_extract.return_value = (1.0, 2.0)
-            mock_bj_name.return_value = "B0613-02"
 
             result = filter_file_data_by_pulsars(file_data, "B0613-02")
 
-            assert result == {"epta_dr2": [file_data["epta_dr2"][0]]}
+            assert result == {"epta_dr2": [epta_file]}
 
     def test_filter_file_data_by_pulsars_mixed_names(self):
         """Test filtering file data by mixed J and B names."""
@@ -630,34 +601,25 @@ class TestPulsarHelperFunctions:
             ],
         }
 
-        with (
-            patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory,
-            patch(
-                "metapulsar.position_helpers.bj_name_from_coordinates_optimized"
-            ) as mock_bj_name,
-            patch(
-                "metapulsar.position_helpers.extract_coordinates_from_parfile_optimized"
-            ) as mock_extract,
-        ):
+        epta_file = _with_catalog_aliases(file_data["epta_dr2"][0], ["J0613-0200"])
+        ppta_file = _with_catalog_aliases(
+            file_data["ppta_dr2"][0],
+            ["J1857+0943", "B1855+09"],
+            path_name="J1857+0943",
+        )
 
+        with patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory:
             mock_instance = mock_factory.return_value
             mock_instance.group_files_by_pulsar.return_value = {
-                "J0613-0200": {"epta_dr2": [file_data["epta_dr2"][0]]},
-                "J1857+0943": {"ppta_dr2": [file_data["ppta_dr2"][0]]},
+                "J0613-0200": {"epta_dr2": [epta_file]},
+                "B1855+09": {"ppta_dr2": [ppta_file]},
             }
 
-            # Mock coordinate extraction and B-name generation
-            mock_extract.side_effect = [
-                (1.0, 2.0),  # For J0613-0200
-                (3.0, 4.0),  # For J1857+0943
-            ]
-            mock_bj_name.side_effect = ["B0613-02", "B1857+09"]
-
-            result = filter_file_data_by_pulsars(file_data, ["J0613-0200", "B1857+09"])
+            result = filter_file_data_by_pulsars(file_data, ["J0613-0200", "B1855+09"])
 
             expected = {
-                "epta_dr2": [file_data["epta_dr2"][0]],
-                "ppta_dr2": [file_data["ppta_dr2"][0]],
+                "epta_dr2": [epta_file],
+                "ppta_dr2": [ppta_file],
             }
             assert result == expected
 
@@ -677,24 +639,13 @@ class TestPulsarHelperFunctions:
             ]
         }
 
-        with (
-            patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory,
-            patch(
-                "metapulsar.position_helpers.bj_name_from_coordinates_optimized"
-            ) as mock_bj_name,
-            patch(
-                "metapulsar.position_helpers.extract_coordinates_from_parfile_optimized"
-            ) as mock_extract,
-        ):
+        epta_file = _with_catalog_aliases(file_data["epta_dr2"][0], ["J0613-0200"])
 
+        with patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory:
             mock_instance = mock_factory.return_value
             mock_instance.group_files_by_pulsar.return_value = {
-                "J0613-0200": {"epta_dr2": [file_data["epta_dr2"][0]]}
+                "J0613-0200": {"epta_dr2": [epta_file]}
             }
-
-            # Mock coordinate extraction and B-name generation
-            mock_extract.return_value = (1.0, 2.0)
-            mock_bj_name.return_value = "B0613-02"
 
             with pytest.raises(
                 ValueError, match="Pulsar 'J9999\\+9999' not found in file data"
@@ -732,24 +683,13 @@ class TestPulsarHelperFunctions:
             ]
         }
 
-        with (
-            patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory,
-            patch(
-                "metapulsar.position_helpers.bj_name_from_coordinates_optimized"
-            ) as mock_bj_name,
-            patch(
-                "metapulsar.position_helpers.extract_coordinates_from_parfile_optimized"
-            ) as mock_extract,
-        ):
+        epta_file = _with_catalog_aliases(file_data["epta_dr2"][0], ["J0613-0200"])
 
+        with patch("metapulsar.metapulsar_factory.MetaPulsarFactory") as mock_factory:
             mock_instance = mock_factory.return_value
             mock_instance.group_files_by_pulsar.return_value = {
-                "J0613-0200": {"epta_dr2": [file_data["epta_dr2"][0]]}
+                "J0613-0200": {"epta_dr2": [epta_file]}
             }
-
-            # Mock coordinate extraction and B-name generation
-            mock_extract.return_value = (1.0, 2.0)
-            mock_bj_name.return_value = "B0613-02"
 
             with pytest.raises(
                 ValueError, match="Pulsar 'J9999\\+9999' not found in file data"

--- a/tests/test_metapulsar_factory.py
+++ b/tests/test_metapulsar_factory.py
@@ -117,11 +117,8 @@ class TestMetaPulsarFactory:
         assert factory.logger is not None
         assert not hasattr(factory, "parfile_manager")
 
-    @patch("metapulsar.position_helpers.bj_name_from_pulsar")
-    def test_create_metapulsar_success(self, mock_bj_name):
+    def test_create_metapulsar_success(self):
         """Test successful MetaPulsar creation using MockLibstempo directly."""
-        # Mock position helper
-        mock_bj_name.return_value = "J1857+0943"
         from metapulsar.mockpulsar import create_mock_libstempo
 
         mock_psr = create_mock_libstempo(
@@ -149,7 +146,7 @@ class TestMetaPulsarFactory:
         empty_file_data = {}
 
         with patch(
-            "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized",
+            "metapulsar.metapulsar_factory.discover_pulsars_by_position",
             return_value={},
         ):
             with pytest.raises(ValueError, match="No valid pulsar files found"):
@@ -180,7 +177,7 @@ class TestMetaPulsarFactory:
         }
 
         with patch(
-            "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized",
+            "metapulsar.metapulsar_factory.discover_pulsars_by_position",
             return_value=mock_pulsar_groups,
         ):
             with pytest.raises(ValueError, match="Multiple pulsars detected"):
@@ -213,7 +210,7 @@ class TestMetaPulsarFactory:
         }
 
         with patch(
-            "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized",
+            "metapulsar.metapulsar_factory.discover_pulsars_by_position",
             return_value=mock_pulsar_groups,
         ):
             # Should not raise an exception
@@ -224,7 +221,7 @@ class TestMetaPulsarFactory:
         empty_file_data = {}
 
         with patch(
-            "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized",
+            "metapulsar.metapulsar_factory.discover_pulsars_by_position",
             return_value={},
         ):
             with pytest.raises(ValueError, match="No valid pulsar files found"):
@@ -269,7 +266,7 @@ class TestMetaPulsarFactory:
         }
 
         with patch(
-            "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized",
+            "metapulsar.metapulsar_factory.discover_pulsars_by_position",
             return_value=expected_groups,
         ):
             result = self.factory.group_files_by_pulsar(file_data)
@@ -306,7 +303,7 @@ class TestMetaPulsarFactory:
         }
 
         with patch(
-            "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized",
+            "metapulsar.metapulsar_factory.discover_pulsars_by_position",
             return_value=mock_pulsar_groups,
         ):
             with patch.object(self.factory, "_ensure_parfile_content") as mock_ensure:
@@ -531,7 +528,7 @@ class TestPerPulsarOrdering:
 
         # Mock the coordinate-based discovery to return grouped data
         with patch(
-            "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized"
+            "metapulsar.metapulsar_factory.discover_pulsars_by_position"
         ) as mock_discover:
             mock_discover.return_value = {
                 "J1857+0943": {
@@ -569,7 +566,7 @@ class TestPerPulsarOrdering:
         }
 
         with patch(
-            "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized"
+            "metapulsar.metapulsar_factory.discover_pulsars_by_position"
         ) as mock_discover:
             mock_discover.return_value = {
                 "J1857+0943": {
@@ -607,7 +604,7 @@ class TestPerPulsarOrdering:
         }
 
         with patch(
-            "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized"
+            "metapulsar.metapulsar_factory.discover_pulsars_by_position"
         ) as mock_discover:
             mock_discover.return_value = {
                 "J1857+0943": {
@@ -730,7 +727,7 @@ class TestPerPulsarOrdering:
         }
 
         with patch(
-            "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized"
+            "metapulsar.metapulsar_factory.discover_pulsars_by_position"
         ) as mock_discover:
             mock_discover.return_value = {
                 "J1857+0943": {
@@ -802,7 +799,7 @@ class TestPtaSummary:
 
         with (
             patch(
-                "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized"
+                "metapulsar.metapulsar_factory.discover_pulsars_by_position"
             ) as mock_discover,
             patch.object(
                 factory, "_get_display_name_for_pulsar", return_value="J1857+0943"
@@ -855,7 +852,7 @@ class TestPtaSummary:
 
         with (
             patch(
-                "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized"
+                "metapulsar.metapulsar_factory.discover_pulsars_by_position"
             ) as mock_discover,
             patch.object(
                 factory, "_get_display_name_for_pulsar", return_value="J1857+0943"
@@ -940,7 +937,7 @@ class TestSinglePtaSharedDmxWarning:
             patch.object(factory, "_ensure_tim_metadata", return_value=file_data),
             patch.object(factory, "_validate_single_pulsar_data"),
             patch(
-                "metapulsar.metapulsar_factory.discover_pulsars_by_coordinates_optimized",
+                "metapulsar.metapulsar_factory.discover_pulsars_by_position",
                 return_value={"J1640+2224": {"ng12": file_data["ng12"]}},
             ),
             patch.object(

--- a/tests/test_metapulsar_with_parameter_manager.py
+++ b/tests/test_metapulsar_with_parameter_manager.py
@@ -1,7 +1,7 @@
 """Tests for MetaPulsar with ParameterManager integration."""
 
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 from pint.models import TimingModel
 from pint.toa import TOAs
 from metapulsar.metapulsar import MetaPulsar, PtaFiles
@@ -164,32 +164,20 @@ class TestMetaPulsarWithParameterManager:
         assert isinstance(result["epta_dr2"], dict)
         mock_t2.savepar.assert_not_called()
 
-    @patch("metapulsar.position_helpers.bj_name_from_pulsar")
-    def test_get_pulsar_name_pint(self, mock_bj_name):
+    def test_get_pulsar_name_pint(self):
         """Test _get_pulsar_name with PINT objects."""
-        # Mock position helper
-        mock_bj_name.return_value = "J1857+0943"
-
-        # Create a minimal MetaPulsar instance for testing
         metapulsar = MetaPulsar.__new__(MetaPulsar)
         metapulsar.logger = Mock()
 
-        # Test with PINT objects
         pulsars = {"epta_dr2": (self.mock_model1, self.mock_toas1)}
         result = metapulsar._get_pulsar_name(pulsars)
         assert result == "J1857+0943"
 
-    @patch("metapulsar.position_helpers.bj_name_from_pulsar")
-    def test_get_pulsar_name_tempo2(self, mock_bj_name):
+    def test_get_pulsar_name_tempo2(self):
         """Test _get_pulsar_name with Tempo2 objects."""
-        # Mock position helper
-        mock_bj_name.return_value = "J1857+0943"
-
-        # Create a minimal MetaPulsar instance for testing
         metapulsar = MetaPulsar.__new__(MetaPulsar)
         metapulsar.logger = Mock()
 
-        # Test with libstempo objects
         pulsars = {"epta_dr2": self.mock_libstempo_psr}
         result = metapulsar._get_pulsar_name(pulsars)
         assert result == "J1857+0943"

--- a/tests/test_position_helpers.py
+++ b/tests/test_position_helpers.py
@@ -21,7 +21,7 @@ from metapulsar.position_helpers import (
     bj_name_from_pulsar,
     extract_coordinates_from_parfile_optimized,
     bj_name_from_coordinates_optimized,
-    discover_pulsars_by_coordinates_optimized,
+    discover_pulsars_by_position,
     _parse_parfile_optimized,
     _get_first_par_value_by_aliases,
     _parse_ra_string_optimized,
@@ -392,15 +392,13 @@ DM 10.0
         }
 
         # Run optimized discovery
-        coordinate_map = discover_pulsars_by_coordinates_optimized(file_data)
+        coordinate_map = discover_pulsars_by_position(file_data)
 
-        # Verify results
+        # Verify results (catalog name from parfile, not truncated coords)
         assert len(coordinate_map) > 0, "No pulsars discovered"
-        assert "J1857+0943" in coordinate_map, "Expected pulsar not found"
-        assert "EPTA" in coordinate_map["J1857+0943"], "PTA not found in results"
-        assert (
-            len(coordinate_map["J1857+0943"]["EPTA"]) == 1
-        ), "Incorrect number of files"
+        group_name = next(iter(coordinate_map))
+        assert "EPTA" in coordinate_map[group_name], "PTA not found in results"
+        assert len(coordinate_map[group_name]["EPTA"]) == 1
 
     def test_optimized_vs_original_consistency(self, load_parfile_text):
         """Test that optimized functions produce same results as original."""

--- a/tests/test_pulsar_identity.py
+++ b/tests/test_pulsar_identity.py
@@ -1,0 +1,183 @@
+"""Tests for catalog + position-based pulsar identity."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+from metapulsar.file_discovery import filter_file_data_by_pulsars
+from metapulsar.layout_discovery import combine_layouts, discover_layout
+from metapulsar.position_helpers import (
+    build_alias_map,
+    discover_pulsars_by_position,
+    letter_suffix,
+    preferred_group_name,
+)
+
+
+def _file_entry(
+    par_path: str,
+    par_content: str,
+    pta: str = "PTA",
+) -> dict:
+    return {
+        "par": par_path,
+        "tim": par_path.replace(".par", ".tim"),
+        "par_content": par_content,
+        "timing_package": "tempo2",
+    }
+
+
+def test_preferred_group_name_b_over_j():
+    assert preferred_group_name(["J1857+0943", "B1855+09"]) == "B1855+09"
+
+
+def test_letter_suffix_cluster_msp():
+    assert letter_suffix("J1824-2452A") == "A"
+    assert letter_suffix("J1857+0943") is None
+    assert letter_suffix("B1855+09") is None
+
+
+def test_merge_b_and_j_catalog_at_same_position():
+    coords = "RAJ 18:57:36.3906121\nDECJ +09:43:17.20714\nF0 1 0\n"
+    file_data = {
+        "ng": [
+            _file_entry(
+                "data/J1857+0943.par",
+                f"PSR J1857+0943\n{coords}",
+            )
+        ],
+        "epta": [
+            _file_entry(
+                "data/B1855+09.par",
+                f"PSR B1855+09\n{coords}",
+            )
+        ],
+    }
+    groups = discover_pulsars_by_position(file_data)
+    assert len(groups) == 1
+    assert "B1855+09" in groups
+    aliases = build_alias_map(groups)
+    assert aliases["J1857+0943"] == "B1855+09"
+    assert aliases["B1855+09"] == "B1855+09"
+
+
+def test_suffix_a_and_b_within_tolerance_separate_groups():
+    coords = "RAJ 18:24:53.5967\nDECJ -24:52:08.87\nF0 1 0\n"
+    file_data = {
+        "pta": [
+            _file_entry(
+                "data/J1824-2452A.par",
+                f"PSRJ J1824-2452A\n{coords}",
+            ),
+            _file_entry(
+                "data/J1824-2452B.par",
+                f"PSRJ J1824-2452B\n{coords}",
+            ),
+        ]
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        groups = discover_pulsars_by_position(file_data)
+    assert len(groups) == 2
+    assert any("different letter suffixes" in str(w.message) for w in caught)
+
+
+def test_suffix_a_and_bare_within_tolerance_raises():
+    coords = "RAJ 18:24:53.5967\nDECJ -24:52:08.87\nF0 1 0\n"
+    file_data = {
+        "pta": [
+            _file_entry(
+                "data/J1824-2452A.par",
+                f"PSRJ J1824-2452A\n{coords}",
+            ),
+            _file_entry(
+                "data/J1824-2452.par",
+                f"PSR J1824-2452\n{coords}",
+            ),
+        ]
+    }
+    with pytest.raises(ValueError, match="Ambiguous pulsar identity"):
+        discover_pulsars_by_position(file_data)
+
+
+def test_same_catalog_name_far_apart_raises():
+    file_data = {
+        "pta": [
+            _file_entry(
+                "data/J0613-0200.par",
+                "PSR J0613-0200\nRAJ 06:13:43.9754\nDECJ -02:00:47.1755\nF0 1 0\n",
+            ),
+            _file_entry(
+                "data/J0613-0200b.par",
+                "PSR J0613-0200\nRAJ 12:00:00.0\nDECJ +00:00:00.0\nF0 1 0\n",
+            ),
+        ]
+    }
+    with pytest.raises(ValueError, match="distinct sky positions"):
+        discover_pulsars_by_position(file_data)
+
+
+def test_j1022_like_scatter_merges_within_10arcsec():
+    """PTA position scatter of a few arcsec with the same catalog name should merge."""
+    # ~5″ apart on sky (same order as data-check J1022+1001 clumps)
+    file_data = {
+        "pta_a": [
+            _file_entry(
+                "data/J1022+1001.par",
+                "PSR J1022+1001\nRAJ 10:22:58.0\nDECJ +10:01:52.0\nF0 1 0\n",
+            )
+        ],
+        "pta_b": [
+            _file_entry(
+                "data/J1022+1001b.par",
+                "PSR J1022+1001\nRAJ 10:22:58.3\nDECJ +10:01:56.0\nF0 1 0\n",
+            )
+        ],
+    }
+    groups = discover_pulsars_by_position(file_data)
+    assert len(groups) == 1
+    assert "J1022+1001" in groups
+    assert set(groups["J1022+1001"]) == {"pta_a", "pta_b"}
+
+
+def test_truncated_coord_name_not_in_alias_map():
+    coords = "RAJ 05:57:44.1\nDECJ +15:50:06.0\nF0 1 0\n"
+    file_data = {
+        "ng": [
+            _file_entry(
+                "data/J0557+1551.par",
+                f"PSR J0557+1551\n{coords}",
+            )
+        ]
+    }
+    groups = discover_pulsars_by_position(file_data)
+    assert "J0557+1551" in groups
+    aliases = build_alias_map(groups)
+    assert "J0557+1551" in aliases
+    assert "J0557+1550" not in aliases
+
+
+@pytest.mark.integration
+def test_data_check_j0557_and_j1824_filter_regression():
+    data_check = Path("/workspaces/metapulsar/data-check")
+    if not (data_check / "NANOGrav_15y").is_dir():
+        pytest.skip("data-check not available")
+
+    ng = discover_layout(str(data_check / "NANOGrav_15y"), verbose=False, name="NG15")
+    ppta = discover_layout(str(data_check / "PPTA_DR3"), verbose=False, name="PPTA_DR3")
+    layouts = combine_layouts(ng, ppta)
+    from metapulsar.file_discovery import discover_files
+
+    files = discover_files(layouts, working_dir=str(data_check), verbose=False)
+
+    out = filter_file_data_by_pulsars(files, "J0557+1551")
+    assert any("J0557+1551" in str(f["par"]) for fl in out.values() for f in fl)
+
+    with pytest.raises(ValueError, match="not found"):
+        filter_file_data_by_pulsars(files, "J0557+1550")
+
+    out_a = filter_file_data_by_pulsars(files, "J1824-2452A")
+    assert any("J1824-2452A" in str(f["par"]) for fl in out_a.values() for f in fl)


### PR DESCRIPTION
## Summary
- Replace truncated coordinate strings (`JHHMM±DDMM`) as pulsar identity with **parfile catalog names** (`PSRJ` / `PSR` / `PSRB`, B-preferred) plus path aliases for lookup.
- Group files by **J2000 angular separation ≤ 10″** (reusing existing PM/frame extractors), with letter-suffix rules so cluster MSPs (`A`/`B`) do not silently merge.
- Fix user-facing failures: `filter_file_data_by_pulsars("J0557+1551")` and `"J1824-2452A"` now resolve; fabricated truncated names (e.g. `J0557+1550`) are rejected unless present in par/path.

## Motivation
Layout/file pairing already speak catalog names. Coordinate truncation is correct astronomy for epoch-stable *positions*, but using those strings as public keys rejected valid loads (last-digit catalog mismatch; letter suffix stripped). Matching should answer “same sky object?”; names should come from the parfile.

## Behavior
| Concern | Rule |
|---|---|
| Matching | J2000 ICRS, `separation ≤ 10″` |
| Public / group name | B-preferred catalog string |
| Lookup | catalog + path aliases only (no truncated coord aliases) |
| Different suffixes within tol | separate groups + warning |
| Mixed suffix vs bare within tol | `ValueError` |
| Same catalog name, sep > 10″ | `ValueError` |

`discover_pulsars_by_coordinates_optimized` remains as a deprecated wrapper around `discover_pulsars_by_position`.

## Test plan
- [x] `tests/test_pulsar_identity.py` (B/J merge, suffix matrix, truncated reject, ~5″ same-name merge)
- [x] Updated factory / filter / discovery unit tests
- [x] `make fast`
- [ ] Optional: full 5-PTA `data-check` discover + filter for `J0557+1551`, `J1824-2452A`, `J1022+1001`, `B1855+09`
- [ ] Optional: `data/ipta-dr2` B1855 / J1909 multi-PTA grouping