### PR TITLE
fix(parameter-manager): align mixed PINT/Tempo2 timing conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,41 @@ print(f"Number of TOAs: {len(metapulsar.toas)}")
 print(f"PTA names: {list(metapulsar._pulsars.keys())}")
 ```
 
+### Cross-engine alignment (`alignment_policy`)
+
+The `consistent` strategy rewrites every PTA's par file onto one common
+PINT/Tempo2 deterministic surface: explicit `TDB`, a shared ephemeris and dated
+clock, numerically transformed ecliptic astrometry, and — when both engines are
+in the stack — explicit `T2CMETHOD`, `TIMEEPH`, troposphere, planetary-Shapiro,
+and solar-wind settings. Deterministic terms outside that surface (`DMMODEL`,
+glitches, WaveX/IFUNC, chromatic extensions, external realization overrides, …)
+are **stripped by default**, with a warning naming the PTA and every removed key.
+
+The default needs no configuration:
+
+```python
+mp = create_metapulsar(files, combination_strategy="consistent")
+```
+
+To be told about unsupported terms instead of having them removed:
+
+```python
+from metapulsar import AlignmentPolicy
+
+mp = create_metapulsar(
+    files,
+    combination_strategy="consistent",
+    alignment_policy=AlignmentPolicy(unsupported="error"),
+)
+```
+
+`AlignmentPolicy` also pins the reference conventions (`ephem`, `clock`,
+`bipm_version`, `ne_sw`). To keep a release's native deterministic model
+untouched, use `combination_strategy="composite"` instead — the policy applies
+only to `consistent` and raises otherwise. See
+[docs/API_REFERENCE.md](docs/API_REFERENCE.md#alignmentpolicy) and
+[docs/METHOD_DESCRIPTION.md](docs/METHOD_DESCRIPTION.md).
+
 ### Pulse-number tracking (`use_pulse_numbers`)
 
 When combining PTAs with `combination_strategy="consistent"`, merged par files can

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -110,7 +110,10 @@ def create_metapulsar(
     reference_pta: str = None,
     combine_components: List[str] = DEFAULT_COMBINE_COMPONENTS,
     add_dm_derivatives: bool = True,
+    exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
     parfile_output_dir: Path = None,
+    use_pulse_numbers: str = "yes",
+    alignment_policy: AlignmentPolicy | None = None,
 ) -> MetaPulsar:
     """Create MetaPulsar using specified combination strategy.
 
@@ -123,8 +126,14 @@ def create_metapulsar(
         combine_components: List of components to make consistent (for consistent strategy).
             Defaults to all components: ["astrometry", "spindown", "binary", "dispersion"]
         add_dm_derivatives: Whether to ensure DM1, DM2 are present in all par files (for consistent strategy)
+        exclude_from_consistent: Canonical parameter names kept PTA-specific even
+            when their component is merged. Defaults to ("DM",).
         parfile_output_dir: Directory to save consistent par files (for consistent strategy only).
             If None, par files are not saved to disk.
+        use_pulse_numbers: Pulse-number mode: "no", "yes" (default), "reuse", "overwrite".
+        alignment_policy: AlignmentPolicy for the multi-PTA common profile.
+            None means AlignmentPolicy(). Passing a policy together with
+            combination_strategy="composite" raises ValueError.
 
     Returns:
         MetaPulsar object
@@ -315,6 +324,63 @@ def combine_layouts(
 
 ## Parameter Management
 
+### AlignmentPolicy
+
+Policy for the multi-PTA `consistent` combination strategy. This is the only
+user-facing knob on the cross-engine alignment; everything else in the profile
+is fixed, because only that combination is validated for residual parity.
+
+```python
+from metapulsar import AlignmentPolicy
+
+
+@dataclass(frozen=True)
+class AlignmentPolicy:
+    unsupported: Literal["strip", "error"] = "strip"
+    ephem: str | None = None
+    clock: str | None = None
+    bipm_version: int | None = None
+    ne_sw: float | None = None
+```
+
+| Field | Meaning |
+|-------|---------|
+| `unsupported` | `"strip"` (default) removes deterministic families outside the common PINT/Tempo2 surface, logging a warning that names the PTA and every removed key. `"error"` raises `ValueError` listing every offender instead. |
+| `ephem` | Override the reference PTA's `EPHEM`. Required when no PTA declares one. |
+| `clock` | Override the reference PTA's `CLOCK`/`CLK`. Required when no PTA declares one. |
+| `bipm_version` | Year used to resolve a bare `TT(BIPM)`, which is otherwise ambiguous across environments and raises. A dated clock that disagrees with this year also raises. |
+| `ne_sw` | Override the resolved constant solar-wind density in cm⁻³. Without it: the reference PTA's explicit `NE_SW`/`NE1AU`/`SOLARN0`, else `4` when Tempo2 is in the stack, else no line. |
+
+Constructor validation: `unsupported` must be `"strip"` or `"error"`, and
+`ne_sw` must be non-negative.
+
+The policy applies only to `combination_strategy="consistent"`. Passing it with
+`"composite"` raises `ValueError` rather than being silently ignored; the
+composite strategy exists precisely to preserve engine-native models.
+
+```python
+# Default: strip unsupported deterministic terms with a warning.
+mp = create_metapulsar(files, combination_strategy="consistent")
+
+# Fail instead of stripping.
+mp = create_metapulsar(
+    files,
+    combination_strategy="consistent",
+    alignment_policy=AlignmentPolicy(unsupported="error"),
+)
+
+# Pin the reference conventions explicitly.
+mp = create_metapulsar(
+    files,
+    combination_strategy="consistent",
+    alignment_policy=AlignmentPolicy(
+        ephem="DE440",
+        clock="TT(BIPM2023)",
+        ne_sw=4.0,
+    ),
+)
+```
+
 ### ParameterManager
 
 Manages parameter consistency across PTAs.
@@ -322,7 +388,7 @@ Manages parameter consistency across PTAs.
 ```python
 class ParameterManager:
     """Manages parameter consistency and mapping across PTAs."""
-    
+
     def __init__(
         self,
         file_data: Dict[str, Dict[str, Any]],
@@ -330,9 +396,17 @@ class ParameterManager:
         add_dm_derivatives: bool = True,
         output_dir: Path = None,
         pulsar_name: str = None,
+        exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
+        alignment_policy: AlignmentPolicy | None = None,
     ):
         """Initialize parameter manager with file data and configuration."""
 ```
+
+`ParameterManager.ell1h_shapiro` reports which orthometric Shapiro expression
+PINT should evaluate for this stack: `"absorbed"` (Freire & Wex 2010, Eq. 28)
+for mixed PINT+Tempo2 stacks, `"full"` (PINT's default, Eq. 29) otherwise. The
+factory passes it to `get_model_and_toas` so materialization matches the
+temporary models built during alignment.
 
 ### ParameterMapping
 

--- a/docs/METHOD_DESCRIPTION.md
+++ b/docs/METHOD_DESCRIPTION.md
@@ -20,16 +20,66 @@ MetaPulsar uses **PINT** and **Tempo2/libstempo** to parse/realize timing models
 * **consistent** (default): make consistent astrophysical timing‑model components across PTAs while preserving detector‑specific timing‑model terms;
 * **composite**: leave all `.par` files untouched and compose them as‑is (useful for diagnostics; everything remains PTA‑specific).
 
+### Step 0: Aggregate switches and the common deterministic surface
+
+For **multi‑PTA** combinations, before anything else, MetaPulsar normalizes what
+the `.par` files are allowed to say:
+
+1. Tempo2's aggregate `TEMPO1` line is expanded into the six explicit states it
+   selects at once (`UNITS TDB`, `TIMEEPH FB90`, `DILATEFREQ N`,
+   `PLANET_SHAPIRO N`, `T2CMETHOD TEMPO`, `CORRECT_TROPOSPHERE N`), then removed.
+   Values already stated explicitly win.
+2. Deterministic terms outside the common PINT/Tempo2 surface are **stripped by
+   default**, with a warning naming the PTA and every removed key. Setting
+   `AlignmentPolicy(unsupported="error")` turns the same finding into a
+   `ValueError` that lists every offender instead.
+
+The stripped families are, by engine set:
+
+| Present engine | Removed |
+|---|---|
+| PINT | `EPHEM_FILE`/`EPH_FILE`, `EOP_FILE`, `CLK_CORR_CHAIN`, `NE_SW_SIN`, `NE_SW_IFUNC`, `DMMODEL` with `_DM`/`_CM`/`DMOFF` and its `CONSTRAIN DMMODEL*` entries, `SATJUMP`, second proper‑motion derivatives, `PMRV`, `DSHK`, `D_AOP`, telescope‑position terms |
+| Tempo2 | `SWM 1` controls (`SWP`, `NE_SW1+`, `SWEPOCH`), `SWX*`, DMWaveX, `VLBIA*` |
+| Both (mixed) | achromatic `WAVE*`/WaveX/`IFUNC*`, `CM` and `CM1+`, `CMX*`/`CHROMX*`/CMWaveX, deterministic chromatic Gaussian / shapelet / event terms, `DMASSPLANET*`, `DPHASEPLANET*`, glitches, piecewise spindown, exponential dips and events |
+
+Matching is by exact name, anchored prefix, or anchored regular expression.
+Noise hyperparameters (EFAC/EQUAD/ECORR, red noise, DM GP, ordinary chromatic
+noise, `DMJUMP`) are **never** matched — there is no generic “starts with
+`DM`/`CM`/`TN`” rule.
+
+`IPM` and `SWM` are value‑dependent: `IPM 0` (Tempo2's interplanetary medium
+off) and `SWM 1` (PINT's non‑constant solar wind) are violations, and under the
+default policy they are normalized rather than merely dropped — see Step 3.
+
+A **single‑PTA** pulsar has no second engine or reference to align against, so
+its native deterministic model is preserved exactly; none of Step 0 or Step 3
+applies to it.
+
+Users who need engine‑native terms preserved should use
+`combination_strategy="composite"`, which performs no alignment at all.
+
 ### Step 1: Unit normalization
 
-MetaPulsar first ensures that all `.par` files are in the same time unit convention:
+MetaPulsar then applies an engine-gated timescale policy:
 
-1. Read all `.par` files. If mixed `UNITS` are detected (TCB vs TDB), convert to **TDB**.
+1. A mixed PINT/Tempo2 multi-PTA stack is always materialized as explicit
+   **TDB**, including a collection in which *all* inputs are TCB. PINT otherwise
+   performs this conversion internally, hiding the representation it actually
+   evaluates from the shared par files.
 
    * For PINT models MetaPulsar re‑emits the model in TDB;
    * For Tempo2 models MetaPulsar calls the `transform tdb` plugin (both paths are implemented).
 
-If all inputs already share the same `UNITS`, no conversion is performed.
+2. A homogeneous PINT-only or Tempo2-only multi-PTA stack keeps its native
+   timescale. A genuinely mixed TCB/TDB collection is normalized to TDB. A
+   Tempo2 par with no `UNITS` line counts as TCB, which is what Tempo2 assumes.
+
+3. A single PTA keeps its native timescale.
+
+4. Converted text is re‑parsed and required to carry an explicit `UNITS TDB`.
+
+The mixed-engine target is one explicit, auditable unit convention; the
+single-engine paths do not rewrite a homogeneous convention unnecessarily.
 
 **No TOA samples are modified** in this step or any subsequent step of this method.
 
@@ -67,69 +117,132 @@ Terminology: in MetaPulsar we use the word consistent to describe model componen
 
 ### Step 3: Make timing‑model conventions consistent
 
-Still inside `_make_parameters_consistent`, **after** the component merge (Step 2) and **before** the consistent `.par` strings are written, MetaPulsar calls `_apply_consistent_convention_rules`. The policy is deliberately small: validate the reference conventions, skip multi‑PTA alignment when there is only one PTA, otherwise discover per‑PTA state and apply only the rules needed for the observed timing engines.
+Still inside `_make_parameters_consistent`, MetaPulsar aligns the conventions
+before the consistent `.par` strings are written. The ordering is fixed:
+numerically transform ecliptic astrometry, align the solar wind, resolve and
+apply the reference conventions, apply the explicit profile, and only then merge
+astrophysical components (Step 2) and clean up dispersion.
 
-**Prerequisites.** The reference PTA must contain `EPHEM` and either `CLOCK` or `CLK`; the convention step raises if either is missing.
+**Prerequisites.** The `EPHEM` and clock realization must be resolvable: from
+`AlignmentPolicy` if supplied, otherwise from the reference PTA's `EPHEM` and
+`CLOCK`/`CLK`. The step raises if either cannot be resolved. A bare `TT(BIPM)`
+is ambiguous across environments and raises unless `AlignmentPolicy.bipm_version`
+pins a year; a dated policy clock that disagrees with `bipm_version` also raises.
 
 **Astrometry guard.** If a parfile contains both equatorial and ecliptic astrometry parameters, `detect_astrometry_style` raises a `ValueError` (surfaced as `RuntimeError` by `_make_parameters_consistent`).
 
 For a **single‑PTA pulsar**, the par/tim rewrite path is still used when needed for DM model cleanup and pulse‑number support. The multi‑PTA convention rules below are skipped because there is no second PTA to align to: `ECL`, `T2CMETHOD`, `EPHEM`, and `CLOCK`/`CLK` are not changed by this step.
 
-For **multi‑PTA pulsars**, MetaPulsar first applies the reference conventions:
+#### Ecliptic astrometry is transformed, never relabelled
 
-1. align `EPHEM` to the reference PTA,
-2. align `CLOCK`/`CLK` to the reference PTA.
+When ecliptic frames have to change, MetaPulsar performs a **numeric coordinate
+transformation** through PINT (`as_ICRS().as_ECL(ecl=...)`), copying back only
+the transformed astrometry fields (`ELONG`, `ELAT`, `PMELONG`, `PMELAT`,
+`POSEPOCH`, `ECL`, and `KOM` for DDK). The physical sky direction and its
+proper‑motion propagation are preserved; only the frame the numbers are
+expressed in changes. Rewriting the `ECL` label alone would move the implied
+direction by ~10⁻⁴ arcsec between `IERS2003` and `IERS2010`, which is why it is
+not done.
 
-Then it applies engine‑specific rules:
+The target obliquity is chosen per stack:
 
-When both PINT and tempo2 PTAs are present:
+- **PINT + Tempo2:** always transform every ecliptic PTA to `IERS2003`;
+- **PINT‑only:** transform only when the `ECL` values differ, to the reference
+  `ECL` (or `IERS2010` when the reference omits it);
+- **Tempo2‑only:** transform only when the `ECL` values differ, to `IERS2003`.
 
-1. ecliptic astrometry: set `ECL IERS2003`,
-2. remove active `T2CMETHOD TEMPO` (only when the first token is `TEMPO`),
-3. equatorial astrometry: remove active `ECL` and emit a warning about the
-   known residual few-ns parity floor for equatorial inputs.
+Equatorial cross‑engine stacks have no active obliquity convention to align:
+their `ECL` line is removed and a warning about the known few‑ns equatorial
+parity floor is emitted.
 
-For single‑engine, multi‑PTA stacks:
+#### Reference conventions
 
-- **PINT-only:** if ecliptic `ECL` values differ (including missing vs present),
-  align to the reference `ECL`; if the reference omits `ECL`, default to
-  `IERS2010`.
-- **Tempo2-only:** if ecliptic `ECL` values differ, align to `IERS2003`; if
-  `T2CMETHOD` values differ, align to the reference PTA's `T2CMETHOD` (which
-  preserves `TEMPO` when already shared in the reference).
+Every PTA adopts the resolved `EPHEM` and clock realization, written under
+whichever alias that PTA already uses (`CLOCK` or `CLK`).
 
-No-op cases:
+#### The explicit mixed‑engine profile
 
-- single PTA: multi‑PTA convention rules are skipped,
-- multi-PTA single-engine stacks that are already homogeneous for the relevant
-  conventions.
+When **both** PINT and Tempo2 are in the stack, MetaPulsar writes the validated
+common profile explicitly rather than relying on either engine's defaults:
 
-`UNITS` normalization remains handled by `_convert_units_if_needed`; convention
-alignment does not force `UNITS`.
+| Surface | Written value |
+|---|---|
+| `UNITS` | `TDB` |
+| `T2CMETHOD` | `IAU2000B` |
+| `TIMEEPH` | `FB90` |
+| `DILATEFREQ` | `N` |
+| `CORRECT_TROPOSPHERE` | `N` |
+| `PLANET_SHAPIRO` | `N` |
+| whole‑Solar‑System Shapiro | enabled: `NO_SS_SHAPIRO` removed |
+| solar wind | `SWM 0` everywhere, `IPM 1` on Tempo2 pars, explicit constant `NE_SW` |
+| ecliptic `ECL` | `IERS2003` (numerically transformed, above) |
+
+`NO_SS_SHAPIRO` is handled independently of `PLANET_SHAPIRO`: the former
+disables the whole Solar‑System Shapiro component including the Sun, the latter
+only the planetary terms.
+
+This profile is **not** applied to single‑engine stacks. In particular a
+PINT‑only multi‑PTA combination keeps whatever troposphere and planetary‑Shapiro
+settings its inputs declare; only `UNITS`, `EPHEM`, the clock, `ECL`, and
+`NE_SW` are aligned there, exactly as before.
+
+| Scenario | Full §4.1 forced profile | `T2CMETHOD TEMPO` | Ecliptic `ECL` |
+|----------|--------------------------|-------------------|----------------|
+| Single PTA | No | Keep | Unchanged |
+| Multi PTA, tempo2-only | No | Align across PTAs; keep `TEMPO` if shared in reference | Transform to `IERS2003` if heterogeneous |
+| Multi PTA, PINT-only | No | N/A | Transform to reference or `IERS2010` if heterogeneous |
+| Multi PTA, PINT + tempo2 | Yes | Force `IAU2000B` | Transform to `IERS2003` |
+| Equatorial + cross-engine | Yes | Force `IAU2000B` | Strip `ECL` + warning |
+
+#### Solar-wind convention (`NE_SW`)
+
+Tempo2 applies an implicit `NE_SW = 4` cm⁻³ when the line is absent; PINT applies none.
+During consistent parfile rewriting MetaPulsar writes one explicit frozen `NE_SW`
+line on every PTA, resolved in this order:
+
+1. `AlignmentPolicy.ne_sw`, when supplied;
+2. the reference par's explicit `NE_SW`, `NE1AU`, or `SOLARN0`;
+3. `4` cm⁻³ when any PTA uses tempo2.
+
+For PINT-only stacks with no reference `NE_SW`, no line is added (PINT effective zero).
+Alias spellings are replaced by the canonical `NE_SW`, and conflicting explicit
+values on non-reference PTAs are overwritten with a warning.
+
+#### Orthometric Shapiro (`H3`/`STIG`/`H4`) in mixed stacks
+
+`H4` and `STIG`/`STIGMA`/`VARSIGMA` are mutually exclusive
+parameterizations. Tempo2 logs that it is ignoring the stigma parameter and
+continues with the approximate `H3`+`H4` model; PINT rejects the combination.
+Every `consistent` invocation therefore raises a focused error before model
+construction, independently of the unsupported-term strip policy. MetaPulsar
+does not silently choose one physical model. `composite` retains native engine
+behavior.
+
+Two mechanisms are needed for ELL1H and `T2` binaries to agree across engines.
+Both apply only to mixed PINT+Tempo2 `consistent` stacks; PINT‑only, composite,
+and single‑PTA paths keep PINT's published defaults.
+
+* **`H3`+`STIG`.** PINT's default evaluates Freire & Wex (2010) Eq. 29, Tempo2's
+  ELL1H mode 1 evaluates Eq. 28. MetaPulsar passes `ell1h_shapiro="absorbed"`
+  to every PINT model build on the mixed‑engine path — factory materialization
+  and the temporary models `ParameterManager` builds during alignment — so both
+  engines evaluate the same delay for the same printed `(A1, EPS1, H3, STIG)`.
+  This selects an evaluator; it does not rewrite the par or convert gauges.
+* **`H3`+`H4`.** PINT floors `NHARMS` at 7 whenever `H4` is set, while Tempo2
+  falls back to `nharm=4` when the keyword is absent. The two spellings are not
+  aliases of each other, so the shared par carries **both** `NHARM` (Tempo2) and
+  `NHARMS` (PINT) at the same value: the largest count any input declared,
+  floored at 7. The count is written after the binary component merge, which is
+  what decides each par's final orthometric model, and is removed entirely when
+  that model turns out to be `H3`+`STIG`.
+
+`tests/test_cross_engine_parity.py` measures both mechanisms by idealizing TOAs
+with PINT and re‑timing them with Tempo2.
 
 For cross-engine parity motivation and validation context, see Luo et al. 2021,
 *ApJ* 911, 45, [doi:10.3847/1538-4357/abe62f](https://doi.org/10.3847/1538-4357/abe62f).
 This method description intentionally does not reproduce the full paper
 regression narrative.
-
-| Scenario | `T2CMETHOD TEMPO` | Ecliptic `ECL` |
-|----------|-------------------|----------------|
-| Single PTA, tempo2-only | Keep | Unchanged |
-| Multi PTA, tempo2-only | Align across PTAs; keep `TEMPO` if shared in reference | Align to `IERS2003` if heterogeneous |
-| Multi PTA, PINT-only | N/A | Align to reference or `IERS2010` if heterogeneous |
-| Multi PTA, PINT + tempo2 | Remove/neutralize | Force `IERS2003` |
-| Equatorial + cross-engine | Remove + warning | Strip `ECL` |
-
-#### Solar-wind convention (`NE_SW`)
-
-Tempo2 applies an implicit `NE_SW = 4` cm⁻³ when the line is absent; PINT applies none.
-During consistent parfile rewriting MetaPulsar aligns an explicit frozen `NE_SW` line when:
-
-1. the reference par has explicit `NE_SW` (that value is used on all PTAs), or
-2. any PTA uses tempo2 (`NE_SW 4 0` on all PTAs).
-
-For PINT-only stacks with no reference `NE_SW`, no line is added (PINT effective zero).
-Conflicting explicit values on non-reference PTAs are overwritten with a warning.
 
 ### Step 4: Build Enterprise pulsars and validate identity
 
@@ -137,6 +250,10 @@ For each PTA MetaPulsar builds an Enterprise pulsar object:
 
 * PINT path: `ep.PintPulsar(TOAs, TimingModel, planets=True)`.
 * Tempo2 path: `ep.Tempo2Pulsar(tempopulsar, planets=True)`.
+
+PINT models are loaded with `allow_T2=True` (so a `T2` binary is resolved to the
+family PINT can evaluate) and, on mixed PINT+Tempo2 `consistent` stacks only,
+with `ell1h_shapiro="absorbed"` (Step 3).
 
 MetaPulsar validates that all PTAs refer to the **same sky position** by converting names to a canonical **J‑name** derived from coordinates. “B‑vs‑J” selection is only for **display**—coordinate matching is authoritative.
 
@@ -209,17 +326,30 @@ Any re‑timing that yields the **same column space** of ( **M** ) produces the 
 
 * It **does not** change TOAs, TOA uncertainties, or backend flags.
 * It **does not** decide noise hyperparameters; EFAC/EQUAD/ECORR and the red/DM noise models are inferred in the usual way in Enterprise/Discovery after the metapulsar is constructed.
+* It **does not** convert `DMMODEL` grids to DMX or to a Taylor expansion, and
+  it does not convert between binary families: `BINARY` lines are left alone and
+  a `T2` model is resolved by PINT's own `allow_T2` guessing.
+* It **does not** rewrite `(A1, EPS1, …)` between the Freire & Wex Eq. 28 and
+  Eq. 29 gauges. Selecting which expression PINT evaluates is in scope;
+  converting the printed parameters is not.
+* It **does not** refit after stripping unsupported terms, nor reconcile the
+  external realizations (clock files, IERS tables, downloaded ephemerides) that
+  each package resolves independently from the same `EPHEM`/`CLK` strings.
+* It **does not** ingest already-combined IPTA data products; MetaPulsar
+  combines per-PTA releases.
 
 ### Minimal algorithm (for reference)
 
-1. **Parse & normalize units** for all PTAs (`UNITS → TDB` only when needed).
-2. **Make consistent** selected components by copying reference PTA values; **leave detector‑specific timing‑model parameters as PTA‑local**; for dispersion: remove DMX, preserve each PTA's local DM value and mark it free, set DMEPOCH (frozen), add DM1/DM2 (free, 0).
-3. **Apply consistent convention rules**: for single‑PTA pulsars, skip multi‑PTA alignment; for multi‑PTA pulsars, align `EPHEM`, `CLOCK/CLK`, then apply cross-engine rules only when both PINT and tempo2 are present, otherwise apply single-engine multi-PTA alignment only when conventions are heterogeneous.
-4. **Instantiate** Enterprise pulsars (PINT or Tempo2 path). Validate same pulsar by coordinates.
-5. **Map parameters** into merged and PTA‑specific meta‑parameters (deterministic mapping).
-6. **Concatenate** per‑PTA arrays (TOAs, flags, etc.) without modification.
-7. **Assemble** the combined design matrix column‑by‑column using the mapping, with explicit unit conversions; drop zero‑information columns.
-8. **Expose** a `MetaPulsar` object fully compatible with Enterprise/Discovery.
+1. **Parse** all PTAs with PINT; for multi‑PTA combinations **expand `TEMPO1`** and **strip (or reject) unsupported deterministic families**.
+2. **Normalize units when required**: mixed PINT/tempo2 stacks use explicit TDB; genuinely mixed TCB/TDB multi-PTA stacks normalize to TDB; homogeneous single-engine and single-PTA inputs keep their native timescale.
+3. **Transform ecliptic astrometry** numerically onto one obliquity convention (never a relabel).
+4. **Apply consistent convention rules**: for single‑PTA pulsars, skip multi‑PTA alignment; for multi‑PTA pulsars, align `NE_SW`, the resolved `EPHEM` and dated clock, then the engine‑gated rules — the full explicit profile when both PINT and tempo2 are present, otherwise only heterogeneous single‑engine conventions.
+5. **Make consistent** selected components by copying reference PTA values; **leave detector‑specific timing‑model parameters as PTA‑local**; for dispersion: remove DMX, preserve each PTA's local DM value and mark it free, set DMEPOCH (frozen), add DM1/DM2 (free, 0). Then normalize the ELL1H harmonic count for the merged binary model.
+6. **Instantiate** Enterprise pulsars (PINT or Tempo2 path). Validate same pulsar by coordinates.
+7. **Map parameters** into merged and PTA‑specific meta‑parameters (deterministic mapping).
+8. **Concatenate** per‑PTA arrays (TOAs, flags, etc.) without modification.
+9. **Assemble** the combined design matrix column‑by‑column using the mapping, with explicit unit conversions; drop zero‑information columns.
+10. **Expose** a `MetaPulsar` object fully compatible with Enterprise/Discovery.
 
 ---
 

--- a/src/metapulsar/__init__.py
+++ b/src/metapulsar/__init__.py
@@ -34,6 +34,7 @@ from .layout_discovery_service import (
     combine_layouts,
 )
 from .parameter_manager import (
+    AlignmentPolicy,
     ParameterManager,
     ParameterMapping,
     ParameterInconsistencyError,
@@ -63,6 +64,7 @@ __all__ = [
     "FileDiscoveryService",
     "PTA_DATA_RELEASES",
     "LayoutDiscoveryService",
+    "AlignmentPolicy",
     "ParameterManager",
     "ParameterMapping",
     "ParameterInconsistencyError",

--- a/src/metapulsar/metapulsar.py
+++ b/src/metapulsar/metapulsar.py
@@ -253,6 +253,7 @@ class MetaPulsar(ep.BasePulsar):
             file_data[pta_name] = {
                 "par": None,
                 "par_content": model.as_parfile(),
+                "timing_package": "pint",
             }
 
         # Handle libstempo pulsars
@@ -261,6 +262,7 @@ class MetaPulsar(ep.BasePulsar):
             file_data[pta_name] = {
                 "par": None,
                 "par_content": parfile_content,
+                "timing_package": "tempo2",
             }
 
         # Create ParameterManager for parameter mapping

--- a/src/metapulsar/metapulsar_factory.py
+++ b/src/metapulsar/metapulsar_factory.py
@@ -19,7 +19,7 @@ except ImportError:
 
 # Import MetaPulsar and ParameterManager
 from .metapulsar import MetaPulsar
-from .parameter_manager import ParameterManager
+from .parameter_manager import AlignmentPolicy, ParameterManager
 from .position_helpers import discover_pulsars_by_coordinates_optimized
 
 # Import PINT for model creation
@@ -32,6 +32,7 @@ except ImportError:
 from .sandbox_tempo2 import tempopulsar
 from .tim_file_analyzer import TimFileAnalyzer, TimMetadata
 from .pint_helpers import (
+    Ell1hShapiroMode,
     PulseNumberMode,
     ensure_pint_track_minus_2,
     pulse_number_tracking_enabled,
@@ -149,6 +150,7 @@ class MetaPulsarFactory:
         exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
         parfile_output_dir: Path = None,
         use_pulse_numbers: str = "yes",
+        alignment_policy: AlignmentPolicy | None = None,
     ) -> MetaPulsar:
         """Create MetaPulsar using specified combination strategy.
 
@@ -178,6 +180,10 @@ class MetaPulsarFactory:
                 - ``"overwrite"``: always re-derive ``-pn`` from original ``par`` + ``tim``.
 
                 Booleans are rejected. Map legacy ``True`` → ``"yes"``, ``False`` → ``"no"``.
+            alignment_policy: :class:`~metapulsar.parameter_manager.AlignmentPolicy`
+                controlling the multi-PTA common profile (``unsupported="strip"``
+                by default, plus optional ``ephem``/``clock``/``bipm_version``/
+                ``ne_sw`` pins). Only valid for the ``"consistent"`` strategy.
 
         Returns:
             MetaPulsar object
@@ -188,6 +194,12 @@ class MetaPulsarFactory:
         """
         self.logger.info(f"Creating MetaPulsar using {combination_strategy} strategy")
         pulse_mode = validate_pulse_number_mode(use_pulse_numbers)
+        if alignment_policy is not None and combination_strategy != "consistent":
+            raise ValueError(
+                "alignment_policy only applies to combination_strategy='consistent'; "
+                f"got {combination_strategy!r}. The composite strategy preserves "
+                "each PTA's native deterministic model and performs no alignment."
+            )
 
         # 1. Ensure parfile content and TIM metadata are loaded
         validated_data = self._ensure_parfile_content(file_data)
@@ -229,6 +241,7 @@ class MetaPulsarFactory:
             parfile_output_dir.mkdir(parents=True, exist_ok=True)
 
         # Process par files based on strategy
+        ell1h_shapiro: Ell1hShapiroMode = "full"
         if combination_strategy == "consistent":
             # Create ParameterManager for parfile consistency
             parameter_manager = ParameterManager(
@@ -238,7 +251,12 @@ class MetaPulsarFactory:
                 output_dir=parfile_output_dir,
                 pulsar_name=pulsar_name,
                 exclude_from_consistent=exclude_from_consistent,
+                alignment_policy=alignment_policy,
             )
+
+            # Mixed PINT+Tempo2 consistent stacks must evaluate the same
+            # orthometric Shapiro expression as tempo2 (see AlignmentPolicy docs).
+            ell1h_shapiro = parameter_manager.ell1h_shapiro
 
             # Make par files consistent
             consistent_parfiles = parameter_manager.make_parfiles_consistent()
@@ -260,6 +278,7 @@ class MetaPulsarFactory:
             file_pairs=file_pairs,
             file_data=single_file_data,
             use_pulse_numbers=pulse_mode,
+            ell1h_shapiro=ell1h_shapiro,
         )
 
         return MetaPulsar(
@@ -455,6 +474,7 @@ class MetaPulsarFactory:
         exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
         parfile_output_dir: Path = None,
         use_pulse_numbers: str = "yes",
+        alignment_policy: AlignmentPolicy | None = None,
     ) -> Dict[str, MetaPulsar]:
         """Create MetaPulsars for all available pulsars using file data.
 
@@ -470,6 +490,8 @@ class MetaPulsarFactory:
                 in selected components.
             parfile_output_dir: Directory to save consistent par files (for consistent strategy only).
                 If None, par files are not saved to disk. Creates subdirectories for each pulsar.
+            alignment_policy: Alignment policy forwarded to each
+                ``create_metapulsar`` call (``"consistent"`` strategy only).
 
         Returns:
             Dictionary mapping pulsar names to MetaPulsar objects
@@ -506,6 +528,7 @@ class MetaPulsarFactory:
                     exclude_from_consistent=exclude_from_consistent,
                     parfile_output_dir=parfile_output_dir,
                     use_pulse_numbers=pulse_mode,
+                    alignment_policy=alignment_policy,
                 )
 
                 # Canonical name is automatically calculated from pulsar data
@@ -684,6 +707,7 @@ class MetaPulsarFactory:
         file_pairs: Dict[str, Tuple[Path, Path]],
         file_data: Dict[str, Dict[str, Any]],
         use_pulse_numbers: PulseNumberMode = "yes",
+        ell1h_shapiro: Ell1hShapiroMode = "full",
     ) -> Dict[str, Any]:
         """Create PINT/Tempo2 objects from file pairs using file data.
 
@@ -692,6 +716,9 @@ class MetaPulsarFactory:
             file_data: Dictionary mapping PTA names to file dictionaries
                       Contains timing_package info from FileDiscoveryService
             use_pulse_numbers: Pulse-number mode (``no``, ``yes``, ``reuse``, ``overwrite``)
+            ell1h_shapiro: ELL1H orthometric Shapiro convention for PINT loads.
+                ``"absorbed"`` on mixed-engine consistent stacks, ``"full"``
+                (PINT's default) otherwise.
 
         Returns:
             Dictionary mapping PTA names to PINT/Tempo2 objects
@@ -723,6 +750,7 @@ class MetaPulsarFactory:
                             tim_path,
                             planets=True,
                             allow_T2=True,
+                            ell1h_shapiro=ell1h_shapiro,
                         )
                         if track_pn:
                             ensure_pint_track_minus_2(model)
@@ -885,6 +913,7 @@ def create_metapulsar(
     exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
     parfile_output_dir: Path = None,
     use_pulse_numbers: str = "yes",
+    alignment_policy: AlignmentPolicy | None = None,
 ) -> MetaPulsar:
     """Create MetaPulsar using specified combination strategy.
 
@@ -905,6 +934,10 @@ def create_metapulsar(
             If None, par files are not saved to disk.
         use_pulse_numbers: Pulse-number mode: ``"no"``, ``"yes"`` (default), ``"reuse"``,
             or ``"overwrite"``. See ``MetaPulsarFactory.create_metapulsar`` for semantics.
+        alignment_policy: :class:`~metapulsar.parameter_manager.AlignmentPolicy`
+            controlling the multi-PTA common profile. ``None`` means
+            ``AlignmentPolicy()``. Passing a policy with ``"composite"`` raises
+            ``ValueError``.
 
     Returns:
         MetaPulsar object
@@ -923,6 +956,7 @@ def create_metapulsar(
         exclude_from_consistent=exclude_from_consistent,
         parfile_output_dir=parfile_output_dir,
         use_pulse_numbers=use_pulse_numbers,
+        alignment_policy=alignment_policy,
     )
 
 
@@ -935,6 +969,7 @@ def create_all_metapulsars(
     exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
     parfile_output_dir: Path = None,
     use_pulse_numbers: str = "yes",
+    alignment_policy: AlignmentPolicy | None = None,
 ) -> Dict[str, MetaPulsar]:
     """Create MetaPulsars for all available pulsars using file data.
 
@@ -952,6 +987,8 @@ def create_all_metapulsars(
             If None, par files are not saved to disk. Creates subdirectories for each pulsar.
         use_pulse_numbers: Pulse-number mode passed to each ``create_metapulsar`` call
             (``"no"``, ``"yes"``, ``"reuse"``, or ``"overwrite"``; default ``"yes"``).
+        alignment_policy: Alignment policy forwarded to each ``create_metapulsar``
+            call (``"consistent"`` strategy only).
 
     Returns:
         Dictionary mapping pulsar names to MetaPulsar objects
@@ -966,6 +1003,7 @@ def create_all_metapulsars(
         exclude_from_consistent=exclude_from_consistent,
         parfile_output_dir=parfile_output_dir,
         use_pulse_numbers=use_pulse_numbers,
+        alignment_policy=alignment_policy,
     )
 
 

--- a/src/metapulsar/parameter_manager.py
+++ b/src/metapulsar/parameter_manager.py
@@ -1080,6 +1080,19 @@ class ParameterManager:
             target_key = aliases[0]
         parfile_dict[target_key] = [value]
 
+    def _set_engine_clock_value(
+        self,
+        pta_name: str,
+        parfile_dict: Dict[str, List[str]],
+        value: str,
+    ) -> None:
+        """Write the resolved clock with the target engine's native keyword."""
+        package = self._normalize_timing_package(self._get_timing_package(pta_name))
+        target_key = "CLK" if package == "tempo2" else "CLOCK"
+        for alias in ("CLOCK", "CLK"):
+            parfile_dict.pop(alias, None)
+        parfile_dict[target_key] = [value]
+
     def _align_reference_conventions(
         self,
         parfile_dicts: Dict[str, Dict[str, List[str]]],
@@ -1087,9 +1100,9 @@ class ParameterManager:
         clock: str,
     ) -> None:
         """Apply the resolved EPHEM and clock convention to every PTA."""
-        for parfile_dict in parfile_dicts.values():
+        for pta_name, parfile_dict in parfile_dicts.items():
             self._set_aliased_value(parfile_dict, ["EPHEM"], ephem)
-            self._set_aliased_value(parfile_dict, ["CLOCK", "CLK"], clock)
+            self._set_engine_clock_value(pta_name, parfile_dict, clock)
 
     def _apply_cross_engine_rules(
         self,

--- a/src/metapulsar/parameter_manager.py
+++ b/src/metapulsar/parameter_manager.py
@@ -9,17 +9,20 @@ This module consolidates all parameter management functionality:
 
 from __future__ import annotations
 
+import re
 import tempfile
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from io import StringIO
-from typing import Dict, List, Any, Tuple, Optional, Set
+from typing import Dict, Iterable, List, Any, Literal, Tuple, Optional, Set
 import logging
 
 from pint.models.model_builder import parse_parfile
 from pint.models.timing_model import TimingModel
 
 from .pint_helpers import (
+    Ell1hShapiroMode,
     resolve_parameter_alias,
     get_aliases_for_parameter,
     create_pint_model,
@@ -33,6 +36,298 @@ from .pint_helpers import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# ===== ALIGNMENT POLICY =====
+
+UnsupportedPolicy = Literal["strip", "error"]
+
+
+@dataclass(frozen=True)
+class AlignmentPolicy:
+    """Policy for the multi-PTA ``consistent`` combination strategy.
+
+    The consistent strategy rewrites every PTA's par file onto one common
+    PINT/Tempo2 deterministic surface. Terms outside that surface are stripped
+    by default; ``unsupported="error"`` turns them into a hard failure instead.
+    Everything else in the profile (TDB, IERS2003, IAU2000B, FB90, and the
+    boolean switches) is fixed, because only that combination is validated for
+    cross-engine residual parity.
+
+    Attributes:
+        unsupported: ``"strip"`` (default) removes unsupported deterministic
+            families with a warning; ``"error"`` raises listing every offender.
+        ephem: Override the reference PTA's ``EPHEM``.
+        clock: Override the reference PTA's ``CLOCK``/``CLK``.
+        bipm_version: Year used to resolve a bare ``TT(BIPM)`` realization.
+        ne_sw: Override the resolved constant solar-wind density in cm^-3.
+    """
+
+    unsupported: UnsupportedPolicy = "strip"
+    ephem: Optional[str] = None
+    clock: Optional[str] = None
+    bipm_version: Optional[int] = None
+    ne_sw: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        if self.unsupported not in {"strip", "error"}:
+            raise ValueError("unsupported must be 'strip' or 'error'")
+        if self.ne_sw is not None and self.ne_sw < 0:
+            raise ValueError("ne_sw must be non-negative")
+
+
+def normalize_timing_package(package: Optional[str]) -> str:
+    """Normalize a timing-package label ('libstempo' is spelled 'tempo2')."""
+    normalized = (package or "pint").strip().lower()
+    return "tempo2" if normalized == "libstempo" else normalized
+
+
+def resolve_ell1h_shapiro_mode(
+    timing_packages: Iterable[Optional[str]],
+) -> Ell1hShapiroMode:
+    """Return the ELL1H Shapiro convention PINT loads should use for a stack.
+
+    Mixed PINT+Tempo2 stacks need PINT's ``"absorbed"`` evaluator (Freire & Wex
+    2010, Eq. 28) to reproduce Tempo2's ELL1H/T2 mode-1 delay for the same
+    printed ``(A1, EPS1, H3, STIG)``. Every other stack keeps PINT's default
+    ``"full"`` (Eq. 29) so published PINT-only solutions are not changed.
+    """
+    packages = {normalize_timing_package(package) for package in timing_packages}
+    return "absorbed" if {"pint", "tempo2"}.issubset(packages) else "full"
+
+
+# ===== TEMPO1 AGGREGATE MODE =====
+
+#: The six explicit states Tempo2's aggregate ``TEMPO1`` switch selects at once.
+TEMPO1_DEFAULTS: Dict[str, List[str]] = {
+    "UNITS": ["TDB"],
+    "TIMEEPH": ["FB90"],
+    "DILATEFREQ": ["N"],
+    "PLANET_SHAPIRO": ["N"],
+    "T2CMETHOD": ["TEMPO"],
+    "CORRECT_TROPOSPHERE": ["N"],
+}
+
+
+def expand_tempo1(par: Dict[str, List[str]]) -> List[str]:
+    """Replace an aggregate ``TEMPO1`` line with its six explicit states.
+
+    Returns the names that were filled in (empty when ``TEMPO1`` is absent).
+    Source-line ordering is irrelevant here because the common profile
+    normalizes all six states afterwards.
+    """
+    tempo1_keys = [key for key in par if key.upper() == "TEMPO1"]
+    if not tempo1_keys:
+        return []
+    for key in tempo1_keys:
+        par.pop(key)
+    present = {key.upper() for key in par}
+    filled = []
+    for key, value in TEMPO1_DEFAULTS.items():
+        if key not in present:
+            par[key] = list(value)
+            filled.append(key)
+    return filled
+
+
+# ===== UNSUPPORTED DETERMINISTIC FAMILIES =====
+#
+# Matching is intentionally explicit: exact names, anchored prefixes, and
+# anchored regular expressions. There is deliberately no generic "starts with
+# DM/CM/TN" rule, because that would swallow noise hyperparameters (EFAC,
+# EQUAD, ECORR, TNRedAmp, TNDMAmp, DMJUMP, ...) which are out of scope here.
+
+#: Tempo2-only or PINT-unsafe surfaces, removed whenever PINT is in the stack.
+_PINT_UNSAFE_EXACT = {
+    "EPHEM_FILE",
+    "EPH_FILE",
+    "EOP_FILE",
+    "CLK_CORR_CHAIN",
+    "NE_SW_SIN",
+    "NE_SW_IFUNC",
+    "_NE_SW",
+    "DMMODEL",
+    "_DM",
+    "_CM",
+    "DMOFF",
+    "SATJUMP",
+    "PMRA2",
+    "PMDEC2",
+    "PMLAMBDA2",
+    "PMBETA2",
+    "PMELONG2",
+    "PMELAT2",
+    "PMRV",
+    "DSHK",
+    "D_AOP",
+    "STEL_DX",
+    "TELEPOCH",
+}
+
+#: PINT-only or Tempo2-unvalidated surfaces, removed whenever Tempo2 is in the stack.
+_TEMPO2_UNSAFE_EXACT = {
+    "SWP",
+    "SWEPOCH",
+    "VLBIAX",
+    "VLBIAY",
+    "VLBIAZ",
+    "DMWXEPOCH",
+}
+
+#: Deterministic extensions outside the common mixed-engine surface.
+_MIXED_UNSAFE_EXACT = {
+    "WAVEEPOCH",
+    "WAVE_OM",
+    "WXEPOCH",
+    "SIFUNC",
+    "CM",
+    "CMEPOCH",
+    "CMWXEPOCH",
+    "DMWXEPOCH",
+    "EXPDIPEPS",
+    "EXPDIPFREF",
+    "CHROMGAUSS_FREF",
+    "TNDMEVENT",
+    "TNSHAPELETEVENT",
+}
+
+_MIXED_UNSAFE_PREFIXES = (
+    "CMX_",
+    "CMWXFREQ_",
+    "CMWXSIN_",
+    "CMWXCOS_",
+    "CHROMX",
+    "WXFREQ_",
+    "WXSIN_",
+    "WXCOS_",
+    "EXPDIPEP_",
+    "EXPDIPAMP_",
+    "EXPDIPIDX_",
+    "EXPDIPTAU_",
+    "CHROMGAUSS_",
+    "EXPEP_",
+    "EXPPH_",
+    "EXPTAU_",
+    "EXPINDEX_",
+    "GAUSEP_",
+    "GAUSAMP_",
+    "GAUSSIG_",
+    "GAUSINDEX_",
+    "PWSTART_",
+    "PWSTOP_",
+    "PWEP_",
+    "PWPH_",
+    "PWF0_",
+    "PWF1_",
+    "PWF2_",
+)
+
+_WAVE_RE = re.compile(r"^WAVE\d+$")
+_IFUNC_RE = re.compile(r"^IFUNC\d+$")
+_CM_DERIVATIVE_RE = re.compile(r"^CM\d+$")
+_GLITCH_RE = re.compile(r"^(?:GLEP|GLPH|GLF0|GLF1|GLF2|GLF0D|GLTD|GLF0D2|GLTD2)_?\d+$")
+_TELESCOPE_RE = re.compile(r"^(?:TELX|TELY|TELZ|TEL_DX)(?:_?\d+)?$")
+_PLANET_PERTURBATION_RE = re.compile(r"^(?:DMASSPLANET|DPHASEPLANET)[1-9]$")
+
+#: Tempo2 controls that stay in the written par but must not reach PINT's
+#: ModelBuilder when a temporary model is built during alignment.
+_TEMPO2_LOCAL_CONTROLS = {"IPM", "FDDC", "FDDI"}
+
+#: Canonical fields copied back after a numeric ecliptic transformation.
+#: Ordered so the rewritten par keeps a deterministic layout.
+_ECL_COPY_KEYS = (
+    "ELONG",
+    "ELAT",
+    "PMELONG",
+    "PMELAT",
+    "POSEPOCH",
+    "ECL",
+    "KOM",  # present for orientation-dependent DDK cases
+)
+
+#: Every input spelling replaced by the transformed astrometry (upper case).
+_ECL_INPUT_ALIASES = frozenset(
+    {
+        "ELONG",
+        "LAMBDA",
+        "ELAT",
+        "BETA",
+        "PMELONG",
+        "PMLAMBDA",
+        "PMELAT",
+        "PMBETA",
+        "ECL",
+    }
+)
+
+_BIPM_CLOCK_RE = re.compile(r"^TT\(BIPM(?P<year>\d{4})?\)$", re.IGNORECASE)
+
+
+def _is_numbered(key: str, stem: str) -> bool:
+    """True when ``key`` is ``stem`` followed by a bare integer index."""
+    if not key.startswith(stem):
+        return False
+    return key[len(stem) :].isdigit()
+
+
+def _is_pint_unsafe(key: str) -> bool:
+    """True for surfaces PINT cannot represent (checked when PINT is present)."""
+    return key in _PINT_UNSAFE_EXACT or _TELESCOPE_RE.fullmatch(key) is not None
+
+
+def _is_tempo2_unsafe(key: str) -> bool:
+    """True for surfaces Tempo2 cannot represent (checked when Tempo2 is present)."""
+    return (
+        key in _TEMPO2_UNSAFE_EXACT
+        or _is_numbered(key, "NE_SW")
+        or key.startswith(("SWX", "DMWX"))
+    )
+
+
+def _is_mixed_unsafe(key: str) -> bool:
+    """True for deterministic terms outside the mixed-engine common surface."""
+    return (
+        key in _MIXED_UNSAFE_EXACT
+        or key.startswith(_MIXED_UNSAFE_PREFIXES)
+        or _WAVE_RE.fullmatch(key) is not None
+        or _IFUNC_RE.fullmatch(key) is not None
+        or _CM_DERIVATIVE_RE.fullmatch(key) is not None
+        or _GLITCH_RE.fullmatch(key) is not None
+        or _PLANET_PERTURBATION_RE.fullmatch(key) is not None
+    )
+
+
+def _first_token(value: Optional[List[str]]) -> Optional[str]:
+    """Return the leading whitespace-separated token of a parsed par value."""
+    if not value:
+        return None
+    parts = str(value[0]).split()
+    return parts[0] if parts else None
+
+
+def dmmodel_constraint_values(par: Dict[str, List[str]]) -> List[str]:
+    """Return ``CONSTRAIN`` entries that constrain a DMMODEL grid."""
+    return [
+        value
+        for value in par.get("CONSTRAIN", [])
+        if value.split() and value.split()[0].upper().startswith("DMMODEL")
+    ]
+
+
+def strip_dmmodel_constraints(par: Dict[str, List[str]]) -> List[str]:
+    """Drop DMMODEL ``CONSTRAIN`` entries, keeping unrelated constraints."""
+    old = par.get("CONSTRAIN", [])
+    removed = dmmodel_constraint_values(par)
+    keep = [value for value in old if value not in removed]
+    if keep:
+        par["CONSTRAIN"] = keep
+    else:
+        par.pop("CONSTRAIN", None)
+    return removed
+
+
+def _set_boolean(par: Dict[str, List[str]], key: str, value: bool) -> None:
+    par[key] = ["Y" if value else "N"]
 
 
 class ParameterManager:
@@ -68,6 +363,7 @@ class ParameterManager:
         output_dir: Path = None,
         pulsar_name: str = None,
         exclude_from_consistent: List[str] | tuple[str, ...] = ("DM",),
+        alignment_policy: Optional[AlignmentPolicy] = None,
     ):
         """Initialize with file data and configuration.
 
@@ -82,6 +378,9 @@ class ParameterManager:
                 Defaults to ("DM",) so each PTA keeps its own reference DM while
                 consistent dispersion still shares DM1/DM2. Pass an empty list to
                 merge all parameters in selected components.
+            alignment_policy: Policy for the multi-PTA common profile. ``None``
+                means ``AlignmentPolicy()`` (strip unsupported families, take
+                ``EPHEM``/clock/``NE_SW`` from the reference PTA).
         """
         self.file_data = file_data
         self.combine_components = combine_components
@@ -91,6 +390,7 @@ class ParameterManager:
         self.exclude_from_consistent = self._normalize_excluded_consistent_parameters(
             exclude_from_consistent
         )
+        self.alignment_policy = alignment_policy or AlignmentPolicy()
 
         # Use first dictionary key as reference (consistent with MetaPulsarFactory)
         self.reference_pta = next(iter(file_data.keys()))
@@ -98,7 +398,36 @@ class ParameterManager:
         self.logger = logger
 
         # Cache for PINT models
-        self._pint_models_cache = None
+        self._pint_models_cache: Optional[Dict[str, TimingModel]] = None
+
+    @property
+    def ell1h_shapiro(self) -> Ell1hShapiroMode:
+        """ELL1H orthometric Shapiro convention used for every PINT model build.
+
+        ``"absorbed"`` on mixed PINT+Tempo2 stacks so temporary models here match
+        the factory's materialization; ``"full"`` (PINT's default) otherwise.
+        """
+        return resolve_ell1h_shapiro_mode(
+            self._get_timing_package(pta_name) for pta_name in self.file_data
+        )
+
+    def _create_model(self, parfile_data: Any) -> TimingModel:
+        """Build a PINT model with this stack's ELL1H Shapiro convention."""
+        return create_pint_model(parfile_data, ell1h_shapiro=self.ell1h_shapiro)
+
+    def _create_model_from_dict(self, par: Dict[str, List[str]]) -> TimingModel:
+        """Build a PINT model from a par dict, minus tempo2-only controls.
+
+        ``IPM``/``FDDC``/``FDDI`` stay in the written par but mean nothing to
+        PINT's ModelBuilder, which would only warn about them.
+        """
+        return self._create_model(
+            {
+                key: value
+                for key, value in par.items()
+                if key.upper() not in _TEMPO2_LOCAL_CONTROLS
+            }
+        )
 
     @property
     def pint_models(self) -> Dict[str, TimingModel]:
@@ -111,12 +440,25 @@ class ParameterManager:
             self._pint_models_cache = {}
             for pta_name in self.file_data.keys():
                 parfile_content = self._get_parfile_content(pta_name)
-                self._pint_models_cache[pta_name] = create_pint_model(parfile_content)
+                self._pint_models_cache[pta_name] = self._create_model(parfile_content)
         return self._pint_models_cache
 
     def _clear_pint_models_cache(self):
         """Clear the PINT models cache."""
         self._pint_models_cache = None
+
+    def _set_pint_models_from_dicts(
+        self, parfile_dicts: Dict[str, Dict[str, List[str]]]
+    ) -> None:
+        """Rebuild the model cache from the current, transformed dictionaries.
+
+        Component discovery must observe the post-strip / post-transform state,
+        not the original ``file_data`` par content.
+        """
+        self._pint_models_cache = {
+            pta_name: self._create_model_from_dict(par)
+            for pta_name, par in parfile_dicts.items()
+        }
 
     def _normalize_excluded_consistent_parameters(
         self, exclude_from_consistent: List[str] | tuple[str, ...]
@@ -139,6 +481,19 @@ class ParameterManager:
         components (astrometry, spindown, binary, dispersion) are have
         consistent values between PTAs.
 
+        Ordering matters and is fixed:
+
+        1. parse with PINT;
+        2. expand aggregate ``TEMPO1``;
+        3. strip (or reject) unsupported deterministic families so later PINT
+           model creation is safe;
+        4. convert every TCB input to TDB;
+        5. numerically transform ecliptic astrometry;
+        6. apply the explicit convention profile (engine-gated);
+        7. copy the selected reference components;
+        8. apply the existing dispersion cleanup;
+        9. serialize.
+
         Args:
             None
 
@@ -153,13 +508,20 @@ class ParameterManager:
         # 1. Parse par files into dictionaries
         parfile_dicts = self._parse_parfiles()
 
-        # 2. Convert units if needed
-        converted_parfiles = self._convert_units_if_needed(parfile_dicts)
+        # 2-3. Expand TEMPO1 and remove unsupported deterministic families
+        self._prepare_common_surface(parfile_dicts)
 
-        # 3. Make parameters consistent
+        # 4. Convert units if needed (every TCB input, not only mixed collections)
+        parfile_contents = {
+            pta_name: dict_to_parfile_string(par, format="pint")
+            for pta_name, par in parfile_dicts.items()
+        }
+        converted_parfiles = self._convert_units_if_needed(parfile_contents)
+
+        # 5-8. Transform astrometry, align conventions, merge components, DM cleanup
         consistent_parfiles = self._make_parameters_consistent(converted_parfiles)
 
-        # 4. Write consistent par files to output directory
+        # 9. Write consistent par files to output directory
         output_files = self._write_consistent_parfiles(consistent_parfiles)
 
         self.logger.info(
@@ -191,40 +553,186 @@ class ParameterManager:
         # 4. Build result
         return self._build_parameter_mapping_result(fitparameters, setparameters)
 
+    # ===== COMMON-SURFACE PREPARATION =====
+
+    def _prepare_common_surface(
+        self, parfile_dicts: Dict[str, Dict[str, List[str]]]
+    ) -> None:
+        """Reject ambiguous models, then prepare the shared deterministic surface.
+
+        Only multi-PTA combinations are rewritten: a single-PTA pulsar has no
+        second engine or reference to align against, so its native deterministic
+        model is preserved. Invalid orthometric parameter combinations are still
+        rejected early for every ``consistent`` invocation.
+        """
+        for pta_name, par in parfile_dicts.items():
+            self._reject_orthometric_conflict(pta_name, par)
+
+        if len(parfile_dicts) < 2:
+            self.logger.info("Common-surface preparation skipped (reason=single_pta)")
+            return
+
+        normalized_packages = self._normalized_timing_packages()
+        has_pint = "pint" in normalized_packages
+        has_tempo2 = "tempo2" in normalized_packages
+        mixed = self._is_cross_engine_mix(normalized_packages)
+
+        for pta_name, par in parfile_dicts.items():
+            filled = expand_tempo1(par)
+            if filled:
+                self.logger.info(
+                    f"PTA {pta_name}: expanded aggregate TEMPO1 into explicit "
+                    f"{', '.join(filled)}"
+                )
+            self._strip_or_error_unsupported(
+                pta_name,
+                par,
+                has_pint=has_pint,
+                has_tempo2=has_tempo2,
+                mixed=mixed,
+            )
+
+    def _reject_orthometric_conflict(
+        self, pta_name: str, par: Dict[str, List[str]]
+    ) -> None:
+        """Reject mutually exclusive H4 and STIG orthometric parameterizations."""
+        present = {key.upper() for key in par}
+        stigma_names = present & {"STIG", "STIGMA", "VARSIGMA"}
+        if "H4" not in present or not stigma_names:
+            return
+
+        stigma = sorted(stigma_names)[0]
+        raise ValueError(
+            f"PTA {pta_name}: invalid orthometric Shapiro model specifies both "
+            f"H4 and {stigma}. Tempo2 would ignore {stigma} and use the "
+            "approximate H4 model, while PINT rejects the combination. Remove "
+            "one parameter explicitly; consistent alignment will not choose a "
+            "physical model on the user's behalf."
+        )
+
+    def _collect_unsupported_keys(
+        self,
+        par: Dict[str, List[str]],
+        *,
+        has_pint: bool,
+        has_tempo2: bool,
+        mixed: bool,
+    ) -> Set[str]:
+        """Return the par keys outside the common deterministic surface."""
+        keys: Set[str] = set()
+        for key in par:
+            upper = key.upper()
+            if has_pint and _is_pint_unsafe(upper):
+                keys.add(key)
+            elif has_tempo2 and _is_tempo2_unsafe(upper):
+                keys.add(key)
+            elif mixed and _is_mixed_unsafe(upper):
+                keys.add(key)
+        keys |= self._unsupported_solar_geometry_keys(
+            par, has_pint=has_pint, has_tempo2=has_tempo2
+        )
+        return keys
+
+    def _unsupported_solar_geometry_keys(
+        self, par: Dict[str, List[str]], *, has_pint: bool, has_tempo2: bool
+    ) -> Set[str]:
+        """Return value-dependent solar-wind geometry violations.
+
+        ``IPM 0`` disables Tempo2's interplanetary medium entirely (PINT has no
+        equivalent switch) and ``SWM 1`` selects PINT's non-constant solar-wind
+        model (Tempo2 has no equivalent). Both are normalized on output rather
+        than merely dropped: see ``_apply_mixed_engine_switches``.
+        """
+        violations: Set[str] = set()
+        for key, value in par.items():
+            upper = key.upper()
+            if has_pint and upper == "IPM" and _first_token(value) == "0":
+                violations.add(key)
+            if has_tempo2 and upper == "SWM" and _first_token(value) == "1":
+                violations.add(key)
+        return violations
+
+    def _strip_or_error_unsupported(
+        self,
+        pta_name: str,
+        par: Dict[str, List[str]],
+        *,
+        has_pint: bool,
+        has_tempo2: bool,
+        mixed: bool,
+    ) -> None:
+        """Apply the policy for every unsupported family found in one par."""
+        keys = self._collect_unsupported_keys(
+            par, has_pint=has_pint, has_tempo2=has_tempo2, mixed=mixed
+        )
+        constraints = dmmodel_constraint_values(par) if has_pint else []
+        if not keys and not constraints:
+            return
+
+        details = sorted(keys) + [f"CONSTRAIN {value}" for value in constraints]
+        if self.alignment_policy.unsupported == "error":
+            raise ValueError(
+                f"PTA {pta_name}: unsupported timing parameters for the consistent "
+                f"common profile: {', '.join(details)}"
+            )
+
+        for key in keys:
+            par.pop(key, None)
+        if constraints:
+            strip_dmmodel_constraints(par)
+        self.logger.warning(
+            f"PTA {pta_name}: stripped unsupported deterministic parameters: "
+            f"{', '.join(details)}"
+        )
+
     # ===== PARFILE CONSISTENCY METHODS =====
 
     def _convert_units_if_needed(
-        self, parfile_dicts: Dict[str, Dict]
+        self, parfile_contents: Dict[str, str]
     ) -> Dict[str, str]:
-        """Convert par files to consistent units (TDB)."""
+        """Normalize timescales only where combination requires it.
+
+        A mixed PINT/Tempo2 stack is always materialized as explicit TDB because
+        PINT otherwise converts TCB models internally. Single-engine stacks keep
+        a homogeneous native timescale; genuinely mixed TCB/TDB collections are
+        normalized to TDB. A single PTA is never rewritten.
+        """
         self.logger.info("Checking if unit conversion is needed")
 
-        # Determine units for all par files
-        file_units, parfile_contents = self._determine_parfile_units()
+        if len(parfile_contents) < 2:
+            self.logger.info("Unit normalization skipped (reason=single_pta)")
+            return parfile_contents
 
-        # Check if all units are the same
+        file_units = self._determine_parfile_units(parfile_contents)
+
         unique_units = set(file_units.values())
-        if len(unique_units) == 1:
+        if unique_units == {"TDB"}:
+            self.logger.info("All par files have TDB units. No conversion needed.")
+            return parfile_contents
+
+        mixed_engines = self._is_cross_engine_mix(self._normalized_timing_packages())
+        if len(unique_units) == 1 and not mixed_engines:
             self.logger.info(
-                f"All par files have {list(unique_units)[0]} units. No conversion needed."
+                "Unit normalization skipped "
+                f"(reason=homogeneous_single_engine, units={next(iter(unique_units))})"
             )
             return parfile_contents
 
-        # Mixed units detected, conversion needed
         self.logger.info(
-            f"Mixed units detected: {unique_units}. Converting TCB files to TDB."
+            f"Non-TDB units detected: {sorted(unique_units)}. "
+            "Converting TCB inputs to TDB."
         )
-        return self._convert_mixed_units(file_units, parfile_contents)
+        return self._convert_tcb_inputs(file_units, parfile_contents)
 
-    def _determine_parfile_units(self) -> Tuple[Dict[str, str], Dict[str, str]]:
+    def _determine_parfile_units(
+        self, parfile_contents: Dict[str, str]
+    ) -> Dict[str, str]:
         """Determine the units of all par files for this pulsar."""
         self.logger.info("Determining units for all par files")
 
         file_units = {}
-        parfile_contents = {}
 
-        for pta_name in self.file_data.keys():
-            parfile_content = self._get_parfile_content(pta_name)
+        for pta_name, parfile_content in parfile_contents.items():
             try:
                 # Parse to check current units
                 parfile_dict = parse_parfile(StringIO(parfile_content))
@@ -232,16 +740,13 @@ class ParameterManager:
                     "UNITS", [self._get_default_time_units(pta_name)]
                 )
                 current_units, _ = parse_parameter_using_pint("UNITS", units_value)
-                current_units = str(current_units).upper()
-
-                file_units[pta_name] = current_units
-                parfile_contents[pta_name] = parfile_content
+                file_units[pta_name] = str(current_units).upper()
 
             except Exception as e:
                 self.logger.error(f"Error reading par file for PTA {pta_name}: {e}")
                 raise RuntimeError(f"Failed to read par file for PTA {pta_name}") from e
 
-        return file_units, parfile_contents
+        return file_units
 
     def _get_default_time_units(self, pta_name: str) -> str:
         """Get the default time units for a PTA based on its timing package.
@@ -255,10 +760,13 @@ class ParameterManager:
         timing_package = self.file_data[pta_name].get("timing_package", "pint")
         return "TDB" if timing_package == "pint" else "TCB"
 
-    def _convert_mixed_units(
+    def _convert_tcb_inputs(
         self, file_units: Dict[str, str], parfile_contents: Dict[str, str]
     ) -> Dict[str, str]:
-        """Convert par files with mixed units to consistent TDB units using appropriate timing package."""
+        """Convert every non-TDB par file to TDB using its own timing package.
+
+        The collection need not be mixed; an all-TCB collection is converted too.
+        """
         converted_parfiles = {}
 
         for pta_name, parfile_content in parfile_contents.items():
@@ -298,13 +806,30 @@ class ParameterManager:
                             f"Tempo2 unit conversion failed for PTA {pta_name}"
                         ) from e
 
+                self._assert_explicit_tdb(pta_name, converted_parfiles[pta_name])
+
         return converted_parfiles
+
+    def _assert_explicit_tdb(self, pta_name: str, parfile_content: str) -> None:
+        """Re-parse converted content and require an explicit ``UNITS TDB``."""
+        parsed = parse_parfile(StringIO(parfile_content))
+        units_value = parsed.get("UNITS")
+        current_units = (
+            str(parse_parameter_using_pint("UNITS", units_value)[0]).upper()
+            if units_value
+            else None
+        )
+        if current_units != "TDB":
+            raise RuntimeError(
+                f"Unit conversion for PTA {pta_name} did not produce an explicit "
+                f"UNITS TDB line (found {current_units!r})"
+            )
 
     def _convert_pint_to_tdb(self, parfile_content: str) -> str:
         """Convert par file from TCB to TDB using PINT ModelBuilder."""
         try:
             # Create PINT model and parse par file
-            model = create_pint_model(parfile_content)
+            model = self._create_model(parfile_content)
 
             # Write par file with TDB units
             new_file = StringIO()
@@ -364,10 +889,7 @@ class ParameterManager:
         return first == "TEMPO"
 
     def _normalize_timing_package(self, package: str) -> str:
-        normalized = (package or "pint").strip().lower()
-        if normalized == "libstempo":
-            return "tempo2"
-        return normalized
+        return normalize_timing_package(package)
 
     def _normalized_timing_packages(self) -> Set[str]:
         return {
@@ -416,7 +938,14 @@ class ParameterManager:
         reference_dict: Dict[str, List[str]],
         normalized_packages: Set[str],
     ) -> Optional[float]:
-        """Resolve the consistent NE_SW density (cm^-3) for this pulsar stack."""
+        """Resolve the consistent NE_SW density (cm^-3) for this pulsar stack.
+
+        Precedence: ``AlignmentPolicy.ne_sw``, then the reference PTA's explicit
+        ``NE_SW``/``NE1AU``/``SOLARN0``, then tempo2's implicit 4 cm^-3 when
+        tempo2 is in the stack.
+        """
+        if self.alignment_policy.ne_sw is not None:
+            return float(self.alignment_policy.ne_sw)
         explicit = self._parse_ne_sw_value(reference_dict)
         if explicit is not None:
             return explicit
@@ -474,99 +1003,121 @@ class ParameterManager:
             }
         return states
 
-    def _require_reference_conventions(
+    def _resolve_reference_conventions(
         self, reference_dict: Dict[str, List[str]]
+    ) -> Tuple[str, str]:
+        """Resolve the EPHEM and clock realization every PTA must adopt.
+
+        Order of precedence: ``AlignmentPolicy`` value, then the reference PTA's
+        value. A bare ``TT(BIPM)`` is ambiguous across environments and must be
+        pinned with ``AlignmentPolicy.bipm_version``.
+        """
+        policy = self.alignment_policy
+
+        ephem = policy.ephem or _first_token(reference_dict.get("EPHEM"))
+        if ephem is None:
+            raise ValueError(
+                "Consistent alignment requires EPHEM: no alias from ['EPHEM'] "
+                f"found in reference PTA {self.reference_pta} and "
+                "AlignmentPolicy.ephem is not set"
+            )
+
+        clock = (
+            policy.clock
+            or _first_token(reference_dict.get("CLOCK"))
+            or _first_token(reference_dict.get("CLK"))
+        )
+        if clock is None:
+            raise ValueError(
+                "Consistent alignment requires a clock realization: no alias "
+                "from ['CLOCK', 'CLK'] found in reference PTA "
+                f"{self.reference_pta} and AlignmentPolicy.clock is not set"
+            )
+
+        return ephem, self._resolve_bipm_clock(clock)
+
+    def _resolve_bipm_clock(self, clock: str) -> str:
+        """Require a dated BIPM realization, resolving a bare ``TT(BIPM)``."""
+        match = _BIPM_CLOCK_RE.match(clock.strip())
+        if match is None:
+            return clock
+
+        version = self.alignment_policy.bipm_version
+        year = match.group("year")
+        if year is None:
+            if version is None:
+                raise ValueError(
+                    f"Bare TT(BIPM) is ambiguous; set AlignmentPolicy.bipm_version "
+                    f"(reference PTA {self.reference_pta})"
+                )
+            return f"TT(BIPM{version})"
+
+        if version is not None and int(year) != int(version):
+            raise ValueError(
+                f"Clock realization {clock!r} disagrees with "
+                f"AlignmentPolicy.bipm_version={version}"
+            )
+        return clock
+
+    def _set_aliased_value(
+        self,
+        parfile_dict: Dict[str, List[str]],
+        aliases: List[str],
+        value: str,
     ) -> None:
-        """Require reference conventions needed for multi-PTA parfile alignment."""
-        if "EPHEM" not in reference_dict:
-            raise ValueError(
-                f"No alias from ['EPHEM'] found in reference PTA {self.reference_pta}"
-            )
-        if "CLOCK" not in reference_dict and "CLK" not in reference_dict:
-            raise ValueError(
-                "No alias from ['CLOCK', 'CLK'] found in reference PTA "
-                f"{self.reference_pta}"
-            )
+        """Write ``value`` under whichever alias this PTA already uses."""
+        target_key = None
+        for alias in aliases:
+            if alias in parfile_dict:
+                if target_key is None:
+                    target_key = alias
+                else:
+                    parfile_dict.pop(alias)
+                    self.logger.error(
+                        f"Dropping duplicate {alias} found in PTA (not {self.reference_pta})"
+                    )
+        if target_key is None:
+            target_key = aliases[0]
+        parfile_dict[target_key] = [value]
 
     def _align_reference_conventions(
         self,
         parfile_dicts: Dict[str, Dict[str, List[str]]],
-        reference_dict: Dict[str, List[str]],
+        ephem: str,
+        clock: str,
     ) -> None:
-        """Apply the reference EPHEM and clock convention to every PTA."""
+        """Apply the resolved EPHEM and clock convention to every PTA."""
         for parfile_dict in parfile_dicts.values():
-            self._align_parameter(parfile_dict, reference_dict, "EPHEM", required=True)
-            self._align_parameter(
-                parfile_dict, reference_dict, ["CLOCK", "CLK"], required=True
-            )
+            self._set_aliased_value(parfile_dict, ["EPHEM"], ephem)
+            self._set_aliased_value(parfile_dict, ["CLOCK", "CLK"], clock)
 
     def _apply_cross_engine_rules(
         self,
         parfile_dicts: Dict[str, Dict[str, List[str]]],
         convention_states: Dict[str, Dict[str, Optional[str]]],
     ) -> None:
-        """Apply convention rules needed when PINT and tempo2 pulsars are mixed."""
+        """Apply convention rules needed when PINT and tempo2 pulsars are mixed.
+
+        Ecliptic frames are handled numerically by
+        ``_transform_ecliptic_for_all``; what remains here is the equatorial
+        case, which has no active obliquity convention to align.
+        """
         for pta_name, parfile_dict in parfile_dicts.items():
-            actions: List[str] = []
             style = convention_states[pta_name]["style"]
-
             if style == "ecliptic":
-                # PINT and tempo2 agree best for ecliptic pars under IERS2003.
-                old_ecl = parfile_dict.get("ECL", ["(missing)"])[0]
-                parfile_dict["ECL"] = ["IERS2003"]
-                actions.append(f"set ECL=IERS2003 (was {old_ecl})")
-            else:
-                # Equatorial pars have no active ECL obliquity convention to align.
-                if "ECL" in parfile_dict:
-                    old_ecl = parfile_dict.pop("ECL")
-                    actions.append(f"removed ECL ({old_ecl[0]})")
-                self.logger.warning(f"[{pta_name}] {self._EQUATORIAL_WARNING}")
-                actions.append("emitted equatorial warning")
+                continue
 
-            if "T2CMETHOD" in parfile_dict and self._is_t2cmethod_tempo(
-                parfile_dict["T2CMETHOD"]
-            ):
-                # Active tempo2 TEMPO mode is a cross-engine convention mismatch.
-                old_t2c = parfile_dict.pop("T2CMETHOD")
-                actions.append(f"removed T2CMETHOD ({old_t2c[0]})")
+            actions: List[str] = []
+            if "ECL" in parfile_dict:
+                old_ecl = parfile_dict.pop("ECL")
+                actions.append(f"removed ECL ({old_ecl[0]})")
+            self.logger.warning(f"[{pta_name}] {self._EQUATORIAL_WARNING}")
+            actions.append("emitted equatorial warning")
 
             self.logger.info(
                 f"PTA {pta_name}: consistent convention rules applied "
                 f"(reason=cross_engine_parity, style={style}); "
-                f"actions: {', '.join(actions) if actions else 'none'}"
-            )
-
-    def _apply_pint_only_rules(
-        self,
-        parfile_dicts: Dict[str, Dict[str, List[str]]],
-        reference_dict: Dict[str, List[str]],
-        convention_states: Dict[str, Dict[str, Optional[str]]],
-    ) -> None:
-        """Align heterogeneous ecliptic conventions for multi-PTA PINT stacks."""
-        ecliptic_ptas = [
-            pta_name
-            for pta_name, state in convention_states.items()
-            if state["style"] == "ecliptic"
-        ]
-        ecliptic_ecl_values = {
-            convention_states[pta_name]["ecl"] for pta_name in ecliptic_ptas
-        }
-
-        if len(ecliptic_ecl_values) <= 1:
-            self.logger.info(
-                "Consistent convention rules skipped "
-                "(reason=homogeneous_ecl_single_engine_pint)"
-            )
-            return
-
-        reference_ecl = self._parse_ecl_value(reference_dict)
-        target_ecl = reference_ecl or "IERS2010"
-        for pta_name in ecliptic_ptas:
-            old_ecl = parfile_dicts[pta_name].get("ECL", ["(missing)"])[0]
-            parfile_dicts[pta_name]["ECL"] = [target_ecl]
-            self.logger.info(
-                f"PTA {pta_name}: consistent convention rules applied "
-                f"(reason=pint_only_ecl_heterogeneous); set ECL={target_ecl} (was {old_ecl})"
+                f"actions: {', '.join(actions)}"
             )
 
     def _apply_tempo2_only_rules(
@@ -575,30 +1126,7 @@ class ParameterManager:
         reference_dict: Dict[str, List[str]],
         convention_states: Dict[str, Dict[str, Optional[str]]],
     ) -> None:
-        """Align heterogeneous ecliptic and T2CMETHOD conventions for tempo2 stacks."""
-        ecliptic_ptas = [
-            pta_name
-            for pta_name, state in convention_states.items()
-            if state["style"] == "ecliptic"
-        ]
-        ecliptic_ecl_values = {
-            convention_states[pta_name]["ecl"] for pta_name in ecliptic_ptas
-        }
-        if len(ecliptic_ecl_values) > 1:
-            for pta_name in ecliptic_ptas:
-                old_ecl = parfile_dicts[pta_name].get("ECL", ["(missing)"])[0]
-                parfile_dicts[pta_name]["ECL"] = ["IERS2003"]
-                self.logger.info(
-                    f"PTA {pta_name}: consistent convention rules applied "
-                    f"(reason=tempo2_only_ecl_heterogeneous); "
-                    f"set ECL=IERS2003 (was {old_ecl})"
-                )
-        else:
-            self.logger.info(
-                "Consistent convention rules skipped "
-                "(reason=homogeneous_ecl_single_engine_tempo2)"
-            )
-
+        """Align heterogeneous T2CMETHOD conventions for tempo2-only stacks."""
         t2_values = {state["t2cmethod"] for state in convention_states.values()}
         if len(t2_values) > 1:
             if "T2CMETHOD" not in reference_dict:
@@ -627,7 +1155,7 @@ class ParameterManager:
         reference_dict: Dict[str, List[str]],
     ) -> None:
         """Apply gated convention rules across consistent parfile dictionaries."""
-        self._require_reference_conventions(reference_dict)
+        ephem, clock = self._resolve_reference_conventions(reference_dict)
         convention_states = self._collect_convention_states(parfile_dicts)
 
         if len(parfile_dicts) == 1:
@@ -635,30 +1163,249 @@ class ParameterManager:
             return
 
         # Multi-PTA combinations share the reference ephemeris and clock.
-        self._align_reference_conventions(parfile_dicts, reference_dict)
+        self._align_reference_conventions(parfile_dicts, ephem, clock)
 
         normalized_packages = self._normalized_timing_packages()
 
         if self._is_cross_engine_mix(normalized_packages):
             self._apply_cross_engine_rules(parfile_dicts, convention_states)
-            return
-
-        if normalized_packages == {"pint"}:
-            self._apply_pint_only_rules(
-                parfile_dicts, reference_dict, convention_states
+        elif normalized_packages == {"pint"}:
+            self.logger.info(
+                "Engine-specific convention rules skipped (reason=single_engine_pint)"
             )
-            return
-
-        if normalized_packages == {"tempo2"}:
+        elif normalized_packages == {"tempo2"}:
             self._apply_tempo2_only_rules(
                 parfile_dicts, reference_dict, convention_states
             )
+        else:
+            self.logger.info(
+                "Engine-specific convention rules skipped "
+                f"(reason=unsupported_packages:{sorted(normalized_packages)})"
+            )
+
+        self._apply_explicit_conventions(parfile_dicts)
+
+    # ===== NUMERIC ECLIPTIC ALIGNMENT =====
+
+    def _resolve_target_ecl(
+        self,
+        reference_dict: Dict[str, List[str]],
+        convention_states: Dict[str, Dict[str, Optional[str]]],
+    ) -> Optional[str]:
+        """Return the obliquity convention every ecliptic PTA must adopt.
+
+        ``None`` means no transformation is needed: single-engine stacks that
+        already share one convention are left alone.
+        """
+        normalized_packages = self._normalized_timing_packages()
+        ecl_values = {
+            state["ecl"]
+            for state in convention_states.values()
+            if state["style"] == "ecliptic"
+        }
+        if not ecl_values:
+            return None
+
+        if self._is_cross_engine_mix(normalized_packages):
+            # PINT and tempo2 agree best for ecliptic pars under IERS2003.
+            return "IERS2003"
+        if len(ecl_values) <= 1:
+            return None
+        if normalized_packages == {"pint"}:
+            return self._parse_ecl_value(reference_dict) or "IERS2010"
+        if normalized_packages == {"tempo2"}:
+            return "IERS2003"
+        return None
+
+    def _transform_ecliptic_for_all(
+        self,
+        parfile_dicts: Dict[str, Dict[str, List[str]]],
+        reference_dict: Dict[str, List[str]],
+    ) -> None:
+        """Numerically move every ecliptic PTA onto one obliquity convention.
+
+        This is a coordinate transformation, never a relabel: the position and
+        proper motion are rotated so the physical direction is preserved.
+        """
+        if len(parfile_dicts) == 1:
+            self.logger.info("Ecliptic alignment skipped (reason=single_pta)")
             return
 
+        convention_states = self._collect_convention_states(parfile_dicts)
+        target_ecl = self._resolve_target_ecl(reference_dict, convention_states)
+        if target_ecl is None:
+            self.logger.info(
+                "Ecliptic alignment skipped (reason=no_transform_required)"
+            )
+            return
+
+        for pta_name, state in convention_states.items():
+            if state["style"] != "ecliptic":
+                continue
+            self._transform_ecliptic_astrometry(
+                pta_name, parfile_dicts[pta_name], target_ecl
+            )
+
+    def _transform_ecliptic_astrometry(
+        self,
+        pta_name: str,
+        par: Dict[str, List[str]],
+        target_ecl: str,
+    ) -> None:
+        """Rotate one PTA's ecliptic astrometry onto ``target_ecl`` using PINT."""
+        source_ecl = self._parse_ecl_value(par)
+
+        try:
+            model = self._create_model_from_dict(par)
+            epoch = model.POSEPOCH.quantity if "POSEPOCH" in model.params else None
+            converted = model.as_ICRS(epoch=epoch).as_ECL(epoch=epoch, ecl=target_ecl)
+            written = StringIO()
+            converted.write_parfile(written)
+            transformed = parse_parfile(StringIO(written.getvalue()))
+        except Exception as e:
+            raise ValueError(
+                f"PTA {pta_name}: ecliptic astrometry conversion "
+                f"{source_ecl or '(missing)'} -> {target_ecl} failed: {e}"
+            ) from e
+
+        for key in list(par):
+            if key.upper() in _ECL_INPUT_ALIASES:
+                par.pop(key)
+        for key in _ECL_COPY_KEYS:
+            value = self._first_alias_value(transformed, key)
+            if value is None:
+                par.pop(key, None)
+            else:
+                par[key] = value
+
         self.logger.info(
-            "Consistent convention rules skipped "
-            f"(reason=unsupported_single_engine_packages:{sorted(normalized_packages)})"
+            f"PTA {pta_name}: transformed ecliptic astrometry "
+            f"{source_ecl or '(missing)'} -> {target_ecl} "
+            "(numeric coordinate conversion, not a relabel)"
         )
+
+    @staticmethod
+    def _first_alias_value(
+        parfile_dict: Dict[str, List[str]], canonical_param: str
+    ) -> Optional[List[str]]:
+        """Return the value stored under any PINT alias of ``canonical_param``."""
+        for alias in get_aliases_for_parameter(canonical_param):
+            if alias in parfile_dict:
+                return parfile_dict[alias]
+        return None
+
+    # ===== EXPLICIT CONVENTION PROFILE =====
+
+    def _apply_explicit_conventions(
+        self, parfile_dicts: Dict[str, Dict[str, List[str]]]
+    ) -> None:
+        """Write the explicit common profile onto every PTA dictionary."""
+        mixed = self._is_cross_engine_mix(self._normalized_timing_packages())
+
+        for pta_name, par in parfile_dicts.items():
+            if mixed:
+                par["UNITS"] = ["TDB"]
+                self._apply_mixed_engine_switches(pta_name, par)
+
+    def _apply_mixed_engine_switches(
+        self, pta_name: str, par: Dict[str, List[str]]
+    ) -> None:
+        """Force the validated PINT+Tempo2 residual-parity switches.
+
+        Applied only to mixed stacks: a PINT-only combination must not have its
+        troposphere or planetary-Shapiro settings flipped to ``N``.
+        """
+        par["T2CMETHOD"] = ["IAU2000B"]
+        par["TIMEEPH"] = ["FB90"]
+        _set_boolean(par, "DILATEFREQ", False)
+        _set_boolean(par, "CORRECT_TROPOSPHERE", False)
+        _set_boolean(par, "PLANET_SHAPIRO", False)
+        # Whole-Solar-System Shapiro stays enabled; it is independent of the
+        # planetary term above.
+        removed_no_ss = par.pop("NO_SS_SHAPIRO", None)
+        par["SWM"] = ["0"]
+        if self._normalize_timing_package(self._get_timing_package(pta_name)) == (
+            "tempo2"
+        ):
+            par["IPM"] = ["1"]
+        else:
+            # IPM is a tempo2 control; PINT output carries no such switch.
+            par.pop("IPM", None)
+
+        if removed_no_ss is not None:
+            self.logger.info(
+                f"PTA {pta_name}: removed NO_SS_SHAPIRO ({removed_no_ss[0]}); "
+                "whole-Solar-System Shapiro enabled"
+            )
+
+    @staticmethod
+    def _declared_nharms(par: Dict[str, List[str]]) -> Optional[int]:
+        """Return the harmonic count declared under either spelling, if any."""
+        present = {key.upper(): key for key in par}
+        for name in ("NHARMS", "NHARM"):
+            key = present.get(name)
+            if key and par.get(key):
+                try:
+                    return int(str(par[key][0]).split()[0])
+                except (TypeError, ValueError, IndexError):
+                    continue
+        return None
+
+    def _align_ell1h_nharms_for_all(
+        self, parfile_dicts: Dict[str, Dict[str, List[str]]]
+    ) -> None:
+        """Give every PTA the same ELL1H harmonic count.
+
+        ``NHARM`` is unknown to PINT and therefore never copied by the binary
+        component merge, so the count has to be resolved once for the stack:
+        the largest value any input declared, floored at 7. A finer truncation
+        is always safe for both engines.
+        """
+        declared = [
+            value
+            for value in (self._declared_nharms(par) for par in parfile_dicts.values())
+            if value is not None
+        ]
+        nharms = max([*declared, 7])
+        for par in parfile_dicts.values():
+            self._align_ell1h_nharms(par, nharms)
+
+    def _align_ell1h_nharms(
+        self, par: Dict[str, List[str]], nharms: Optional[int] = None
+    ) -> None:
+        """Ensure NHARM (tempo2) and NHARMS (PINT) >= 7 for H3+H4 ELL1H/T2 pars.
+
+        PINT floors ``NHARMS`` at 7 whenever ``H4`` is set, while tempo2 defaults
+        to ``nharm=4`` when the keyword is absent. The two spellings are not
+        aliases of each other, so a shared par has to carry both.
+
+        Not applied for the ``H3``+``STIG`` orthometric path: both engines ignore
+        the harmonic count there (see ``ell1h_shapiro``). A count left over from
+        the input is dropped in that case, because component merging can replace
+        an ``H3``+``H4`` model with an ``H3``+``STIG`` one.
+
+        Must run *after* the component merge, which is what decides the final
+        binary model of each written par.
+        """
+        present = {key.upper(): key for key in par}
+        has_stig = "STIG" in present or "STIGMA" in present
+        if has_stig:
+            for name in ("NHARM", "NHARMS"):
+                if name in present:
+                    par.pop(present[name])
+            return
+        if "H4" not in present:
+            return
+        if "H3" not in present:
+            return
+
+        if nharms is None:
+            declared = self._declared_nharms(par)
+            nharms = 7 if declared is None else max(declared, 7)
+
+        # Dual emit: tempo2 reads NHARM; PINT reads NHARMS (no cross-alias).
+        par[present.get("NHARM", "NHARM")] = [str(nharms)]
+        par[present.get("NHARMS", "NHARMS")] = [str(nharms)]
 
     def _make_parameters_consistent(
         self, parfile_data: Dict[str, str]
@@ -669,15 +1416,18 @@ class ParameterManager:
         make par models consistent across PTAs. Method:
 
         - Start with parfiles that have been unit-converted (done)
-        - Get all parameters from the reference PTA
+        - Numerically transform ecliptic astrometry onto one obliquity
+          convention (a coordinate rotation, never a relabel)
+        - Align explicit NE_SW when required for tempo2/PINT parity
+        - Always align CLOCK and EPHEM parameters, and write the explicit
+          convention profile (engine-gated; see ``_apply_explicit_conventions``)
+        - Rebuild the PINT model cache from these transformed dictionaries
         - Determine which model 'components' (astrometry, spindown, etc.) are
           being made consistent, and find all parameters in the models
         - For each component, replace the parameters with the values of the
           reference PTA
         - For dispersion, remove DMX parameters
         - Optionally, add DM1 and DM2 parameters
-        - Align explicit NE_SW when required for tempo2/PINT parity
-        - Always align CLOCK and EPHEM parameters
         - Convert back to par file strings
         - Write consistent par files to output directory
 
@@ -706,8 +1456,27 @@ class ParameterManager:
                     f"Failed to parse par file for PTA {pta_name}"
                 ) from e
 
-        # Get reference PTA parameters
+        # Get reference PTA parameters (mutated in place by the steps below)
         reference_dict = parfile_dicts[self.reference_pta]
+
+        # Numerically transform ecliptic astrometry onto one obliquity convention.
+        try:
+            self._transform_ecliptic_for_all(parfile_dicts, reference_dict)
+        except ValueError as e:
+            self.logger.error(f"Ecliptic astrometry alignment failed: {e}")
+            raise RuntimeError(f"Ecliptic astrometry alignment failed: {e}") from e
+
+        # Align the solar-wind amplitude and the explicit convention profile.
+        self._align_ne_sw_convention(parfile_dicts, reference_dict)
+        try:
+            self._apply_consistent_convention_rules(parfile_dicts, reference_dict)
+        except ValueError as e:
+            self.logger.error(f"Consistent convention rules failed: {e}")
+            raise RuntimeError(f"Consistent convention rules failed: {e}") from e
+
+        # Component discovery must observe the transformed dictionaries, not the
+        # original file_data cache.
+        self._set_pint_models_from_dicts(parfile_dicts)
 
         # Pre-compute component parameters for ALL components
         component_params_map = {}
@@ -746,14 +1515,9 @@ class ParameterManager:
                     dmx_params_map,
                 )
 
-        self._align_ne_sw_convention(parfile_dicts, reference_dict)
-
-        # Apply reference and engine-specific conventions after component updates.
-        try:
-            self._apply_consistent_convention_rules(parfile_dicts, reference_dict)
-        except ValueError as e:
-            self.logger.error(f"Consistent convention rules failed: {e}")
-            raise RuntimeError(f"Consistent convention rules failed: {e}") from e
+        # The binary component merge decides each par's final orthometric model,
+        # so the harmonic count is normalized last.
+        self._align_ell1h_nharms_for_all(parfile_dicts)
 
         # Convert back to par file strings
         consistent_parfiles = {}
@@ -858,7 +1622,7 @@ class ParameterManager:
     def _get_dmx_parameters_from_parfile(self, parfile_dict: Dict) -> List[str]:
         """Get DMX parameters from a parfile using PINT component discovery."""
         # Create PINT model directly from dictionary
-        model = create_pint_model(parfile_dict)
+        model = self._create_model_from_dict(parfile_dict)
 
         # Find DMX parameters from dispersion_dmx component
         dmx_params = []
@@ -930,7 +1694,7 @@ class ParameterManager:
         pint_models = {}
         for pta_name in self.file_data.keys():
             parfile_content = self._get_parfile_content(pta_name)
-            pint_models[pta_name] = create_pint_model(parfile_content)
+            pint_models[pta_name] = self._create_model(parfile_content)
 
         for pta_name, model in pint_models.items():
             self._process_pta_parameters(
@@ -1059,7 +1823,7 @@ class ParameterManager:
         """Check if component type is available across all PINT models."""
         for pta_name in self.file_data.keys():
             parfile_content = self._get_parfile_content(pta_name)
-            model = create_pint_model(parfile_content)
+            model = self._create_model(parfile_content)
 
             if not check_component_available_in_model(model, component_type):
                 return False
@@ -1071,7 +1835,7 @@ class ParameterManager:
             return False
 
         parfile_content = self._get_parfile_content(pta_name)
-        model = create_pint_model(parfile_content)
+        model = self._create_model(parfile_content)
         return get_parameter_identifiability_from_model(model, param_name)
 
     def _parse_parfiles(self) -> Dict[str, Dict]:
@@ -1086,8 +1850,12 @@ class ParameterManager:
         return self.file_data[pta_name]["par_content"]
 
     def _get_timing_package(self, pta_name: str) -> str:
-        """Get timing package for a specific PTA from file data."""
-        return self.file_data[pta_name]["timing_package"]
+        """Get timing package for a specific PTA from file data.
+
+        Defaults to ``"pint"``: parameter-mapping callers build ``file_data``
+        from already-materialized models and do not carry the key.
+        """
+        return self.file_data[pta_name].get("timing_package", "pint")
 
     def _convert_tempo2_to_tdb(self, parfile_content: str) -> str:
         """Convert par file from TCB to TDB using tempo2 subprocess."""

--- a/src/metapulsar/pint_helpers.py
+++ b/src/metapulsar/pint_helpers.py
@@ -19,6 +19,11 @@ import numpy as np
 if TYPE_CHECKING:
     from .tim_file_analyzer import TimMetadata
 
+#: Which orthometric Shapiro expression PINT evaluates for ELL1H/``T2`` binaries.
+#: ``"full"`` is PINT's default (Freire & Wex 2010, Eq. 29); ``"absorbed"``
+#: (Eq. 28) matches Tempo2's ELL1H/T2 mode 1.
+Ell1hShapiroMode = Literal["full", "absorbed"]
+
 
 class PINTDiscoveryError(Exception):
     """Raised when PINT component discovery fails"""
@@ -314,13 +319,16 @@ def get_parameters_by_type_from_models(
 
 
 def get_parameters_by_type_from_parfiles(
-    param_type: str, parfile_dicts: Dict[str, Dict]
+    param_type: str,
+    parfile_dicts: Dict[str, Dict],
+    ell1h_shapiro: Ell1hShapiroMode = "full",
 ) -> List[str]:
     """Get parameters by type from parfile dictionaries using PINT, including dynamic derivatives and aliases.
 
     Args:
         param_type: Type of parameters to discover ('astrometry', 'spindown', etc.)
         parfile_dicts: Dictionary mapping PTA names to parfile dictionaries
+        ell1h_shapiro: ELL1H orthometric Shapiro convention (see ``create_pint_model``)
 
     Returns:
         List of parameter names discovered from actual parfiles, including all aliases
@@ -334,7 +342,9 @@ def get_parameters_by_type_from_parfiles(
     pint_models = {}
     for pta_name, parfile_dict in parfile_dicts.items():
         try:
-            pint_models[pta_name] = create_pint_model(parfile_dict)
+            pint_models[pta_name] = create_pint_model(
+                parfile_dict, ell1h_shapiro=ell1h_shapiro
+            )
         except Exception as e:
             logger.warning(f"Failed to create PINT model for PTA {pta_name}: {e}")
             continue
@@ -343,11 +353,18 @@ def get_parameters_by_type_from_parfiles(
     return get_parameters_by_type_from_models(param_type, pint_models)
 
 
-def create_pint_model(parfile_data) -> TimingModel:
+def create_pint_model(
+    parfile_data: Any, ell1h_shapiro: Ell1hShapiroMode = "full"
+) -> TimingModel:
     """Create PINT model from parfile data (string or dict).
 
     Args:
         parfile_data: String content or dictionary representation of parfile
+        ell1h_shapiro: Which Freire & Wex (2010) orthometric Shapiro expression PINT
+            evaluates for ELL1H/``T2`` models with ``H3``+``STIG``. ``"full"`` is
+            PINT's default (Eq. 29); ``"absorbed"`` (Eq. 28) is what Tempo2
+            ELL1H/T2 mode 1 evaluates and is required for cross-engine residual
+            parity on mixed PINT+Tempo2 stacks.
 
     Returns:
         PINT TimingModel instance
@@ -371,9 +388,13 @@ def create_pint_model(parfile_data) -> TimingModel:
 
         # Handle both string and dict inputs
         if isinstance(parfile_data, str):
-            model = builder(StringIO(parfile_data), allow_tcb=True, allow_T2=True)
-        else:  # dict
-            model = builder(parfile_data, allow_tcb=True, allow_T2=True)
+            parfile_data = StringIO(parfile_data)
+        model = builder(
+            parfile_data,
+            allow_tcb=True,
+            allow_T2=True,
+            ell1h_shapiro=ell1h_shapiro,
+        )
 
         return model
     except (

--- a/tests/fixtures/release_shapes/README.md
+++ b/tests/fixtures/release_shapes/README.md
@@ -1,0 +1,22 @@
+# Release-shape fixtures
+
+Compact par files representing the deterministic-model shapes MetaPulsar meets
+in current and development PTA releases. They exist so the consistent
+combination strategy can be exercised end-to-end without any local data
+release; see `tests/test_release_shape_alignment.py`.
+
+All files describe the same synthetic source so they can be combined:
+an ecliptic-coordinate binary MSP at `ELONG 244.35 / ELAT -10.07`.
+
+| File | Engine | Shape under test |
+|------|--------|------------------|
+| `nanograv_style.par` | pint | `SOLARN0 0`, `T2CMETHOD TEMPO`, `ECL IERS2010`, DMX bins, FD + JUMP + TZR |
+| `epta_style.par` | tempo2 | all-TCB, `TIMEEPH IF99`, troposphere/planet Shapiro on, `NO_SS_SHAPIRO`, `T2` binary with `H3`+`H4` and no harmonic count |
+| `ppta_style.par` | tempo2 | aggregate `TEMPO1`, incidental `DMMODEL` grid with `CONSTRAIN DMMODEL`, `ECL IERS2003` |
+| `mpta_style.par` | pint | development PINT extensions: `SWM 1` + `SWX*` + `NE_SW1`, DMWaveX, WaveX, `CM`/`CMX` |
+| `pint_only_a.par`, `pint_only_b.par` | pint | PINT-only multi-PTA stack with troposphere and planetary Shapiro enabled |
+| `binary_ell1h_h3stig.par` | pint | ELL1H orthometric `H3`+`STIG` (absorbed-Shapiro path) |
+| `binary_ddk.par` | tempo2 | DDK with `KIN`/`KOM`, for the ecliptic `KOM` transformation |
+
+The values are synthetic and deliberately unphysical in detail; only the
+*shape* of the deterministic model matters here.

--- a/tests/fixtures/release_shapes/binary_ddk.par
+++ b/tests/fixtures/release_shapes/binary_ddk.par
@@ -1,0 +1,26 @@
+# DDK: the orbital orientation KOM must follow the ecliptic transformation.
+PSR              J1600-3053
+EPHEM            DE436
+CLK              TT(BIPM2015)
+UNITS            TDB
+LAMBDA           244.347677 1
+BETA             -10.071873 1
+PMLAMBDA         -0.35 1
+PMBETA           -7.0 1
+PX               0.50 1
+ECL              IERS2010
+POSEPOCH         55000
+F0               277.937 1
+F1               -7.3e-16 1
+PEPOCH           55000
+DM               52.3
+DMEPOCH          55000
+BINARY           DDK
+PB               14.348466 1
+A1               8.801653 1
+T0               55000.0 1
+ECC              1.737e-04 1
+OM               181.85 1
+M2               0.33 1
+KIN              68.0 1
+KOM              76.0 1

--- a/tests/fixtures/release_shapes/binary_ell1h_h3stig.par
+++ b/tests/fixtures/release_shapes/binary_ell1h_h3stig.par
@@ -1,0 +1,24 @@
+# ELL1H orthometric Shapiro via H3+STIG (the absorbed-evaluator path).
+PSR              J1600-3053
+EPHEM            DE440
+CLOCK            TT(BIPM2021)
+UNITS            TDB
+ELONG            244.347677 1
+ELAT             -10.071873 1
+PMELONG          -0.35 1
+PMELAT           -7.0 1
+ECL              IERS2003
+POSEPOCH         55000
+F0               277.937 1
+F1               -7.3e-16 1
+PEPOCH           55000
+DM               52.3
+DMEPOCH          55000
+BINARY           ELL1H
+PB               14.348466 1
+A1               8.801653 1
+TASC             55000.0 1
+EPS1             1.7e-05 1
+EPS2             -9.1e-06 1
+H3               1.2e-07 1
+STIG             0.72 1

--- a/tests/fixtures/release_shapes/epta_style.par
+++ b/tests/fixtures/release_shapes/epta_style.par
@@ -1,0 +1,37 @@
+# EPTA-style shape: TCB units, IF99, troposphere/planet on, NO_SS_SHAPIRO,
+# T2 binary with orthometric H3+H4 and no explicit harmonic count.
+PSR              J1600-3053
+EPHEM            DE436
+CLK              TT(BIPM2015)
+UNITS            TCB
+TIMEEPH          IF99
+CORRECT_TROPOSPHERE Y
+PLANET_SHAPIRO   Y
+DILATEFREQ       Y
+NO_SS_SHAPIRO
+LAMBDA           244.347677 1
+BETA             -10.071873 1
+PMLAMBDA         -0.35 1
+PMBETA           -7.0 1
+PX               0.50 1
+ECL              IERS2010
+POSEPOCH         55000
+F0               277.937 1
+F1               -7.3e-16 1
+PEPOCH           55000
+DM               52.3
+DMEPOCH          55000
+BINARY           T2
+PB               14.348466 1
+A1               8.801653 1
+TASC             55000.0 1
+EPS1             1.7e-05 1
+EPS2             -9.1e-06 1
+H3               1.2e-07 1
+H4               6.0e-08 1
+JUMP -B 20CM 3.1e-06 1
+FDDC             1.0
+FDDI             2.0
+TZRMJD           55000.0
+TZRSITE          eff
+TZRFRQ           1400.0

--- a/tests/fixtures/release_shapes/mpta_style.par
+++ b/tests/fixtures/release_shapes/mpta_style.par
@@ -1,0 +1,43 @@
+# Development PINT shape: non-constant solar wind, DMWaveX, WaveX, chromatic CM.
+PSR              J1600-3053
+EPHEM            DE440
+CLOCK            TT(BIPM2021)
+UNITS            TDB
+ELONG            244.347677 1
+ELAT             -10.071873 1
+PMELONG          -0.35 1
+PMELAT           -7.0 1
+ECL              IERS2003
+POSEPOCH         55000
+F0               277.937 1
+F1               -7.3e-16 1
+PEPOCH           55000
+DM               52.3
+DMEPOCH          55000
+NE_SW            5.0
+NE_SW1           0.1
+SWM              1
+SWP              2.0
+SWEPOCH          55000
+SWXDM_0001       0.01 1
+SWXR1_0001       54500.0
+SWXR2_0001       54600.0
+DMWXEPOCH        55000
+DMWXFREQ_0001    0.0002
+DMWXSIN_0001     1e-05 1
+DMWXCOS_0001     2e-05 1
+WXEPOCH          55000
+WXFREQ_0001      0.0002
+WXSIN_0001       1e-08 1
+WXCOS_0001       2e-08 1
+CM               0.5 1
+CMEPOCH          55000
+CMX_0001         0.01 1
+BINARY           ELL1
+PB               14.348466 1
+A1               8.801653 1
+TASC             55000.0 1
+EPS1             1.7e-05 1
+EPS2             -9.1e-06 1
+TNRedAmp         -14.2
+TNRedGam         3.1

--- a/tests/fixtures/release_shapes/nanograv_style.par
+++ b/tests/fixtures/release_shapes/nanograv_style.par
@@ -1,0 +1,40 @@
+# NANOGrav-style shape: SOLARN0 0, T2CMETHOD TEMPO, IERS2010, DMX, FD, JUMP, TZR
+PSR              J1600-3053
+EPHEM            DE436
+CLOCK            TT(BIPM2017)
+UNITS            TDB
+T2CMETHOD        TEMPO
+PLANET_SHAPIRO   Y
+ELONG            244.347677 1
+ELAT             -10.071873 1
+PMELONG          -0.35 1
+PMELAT           -7.0 1
+PX               0.50 1
+ECL              IERS2010
+POSEPOCH         55000
+F0               277.937 1
+F1               -7.3e-16 1
+PEPOCH           55000
+DM               52.3
+DMEPOCH          55000
+DMX              14.0
+DMX_0001         0.0012 1
+DMXR1_0001       54500.0
+DMXR2_0001       54514.0
+DMX_0002         -0.0007 1
+DMXR1_0002       54600.0
+DMXR2_0002       54614.0
+SOLARN0          0.00
+BINARY           ELL1
+PB               14.348466 1
+A1               8.801653 1
+TASC             55000.0 1
+EPS1             1.7e-05 1
+EPS2             -9.1e-06 1
+FD1              1.2e-05 1
+FD2              -3.4e-06 1
+JUMP -fe Rcvr_800 1.5e-06 1
+JUMP -fe Rcvr1_2 -2.5e-06 1
+TZRMJD           55000.0
+TZRSITE          ao
+TZRFRQ           1400.0

--- a/tests/fixtures/release_shapes/pint_only_a.par
+++ b/tests/fixtures/release_shapes/pint_only_a.par
@@ -1,0 +1,24 @@
+# PINT-only stack member A: troposphere and planetary Shapiro deliberately on.
+PSR              J1600-3053
+EPHEM            DE440
+CLOCK            TT(BIPM2021)
+UNITS            TDB
+CORRECT_TROPOSPHERE Y
+PLANET_SHAPIRO   Y
+ELONG            244.347677 1
+ELAT             -10.071873 1
+PMELONG          -0.35 1
+PMELAT           -7.0 1
+ECL              IERS2010
+POSEPOCH         55000
+F0               277.937 1
+F1               -7.3e-16 1
+PEPOCH           55000
+DM               52.3
+DMEPOCH          55000
+BINARY           ELL1
+PB               14.348466 1
+A1               8.801653 1
+TASC             55000.0 1
+EPS1             1.7e-05 1
+EPS2             -9.1e-06 1

--- a/tests/fixtures/release_shapes/pint_only_b.par
+++ b/tests/fixtures/release_shapes/pint_only_b.par
@@ -1,0 +1,24 @@
+# PINT-only stack member B: same source, different obliquity label.
+PSR              J1600-3053
+EPHEM            DE438
+CLOCK            TT(BIPM2019)
+UNITS            TDB
+CORRECT_TROPOSPHERE Y
+PLANET_SHAPIRO   Y
+ELONG            244.347677 1
+ELAT             -10.071873 1
+PMELONG          -0.35 1
+PMELAT           -7.0 1
+ECL              IERS2003
+POSEPOCH         55000
+F0               277.937 1
+F1               -7.3e-16 1
+PEPOCH           55000
+DM               52.4
+DMEPOCH          55000
+BINARY           ELL1
+PB               14.348466 1
+A1               8.801653 1
+TASC             55000.0 1
+EPS1             1.7e-05 1
+EPS2             -9.1e-06 1

--- a/tests/fixtures/release_shapes/ppta_style.par
+++ b/tests/fixtures/release_shapes/ppta_style.par
@@ -1,0 +1,26 @@
+# PPTA-style shape: aggregate TEMPO1 mode plus an incidental DMMODEL grid.
+PSR              J1600-3053
+EPHEM            DE421
+CLK              TT(BIPM2013)
+TEMPO1
+LAMBDA           244.347677 1
+BETA             -10.071873 1
+PMLAMBDA         -0.35 1
+PMBETA           -7.0 1
+ECL              IERS2003
+POSEPOCH         55000
+F0               277.937 1
+F1               -7.3e-16 1
+PEPOCH           55000
+DM               52.3
+DMEPOCH          55000
+DMMODEL          1
+CONSTRAIN        DMMODEL
+_DM 54500.0 0.001 1
+_DM 54600.0 -0.002 1
+BINARY           ELL1
+PB               14.348466 1
+A1               8.801653 1
+TASC             55000.0 1
+EPS1             1.7e-05 1
+EPS2             -9.1e-06 1

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -95,7 +95,18 @@ C 12345.67890 0.0001
                             {
                                 "par": Path(temp_dir) / "J0030+0451.par",
                                 "tim": temp_tim,
-                                "par_content": "PSR J0030+0451\nRAJ 00:30:27.4\nDECJ 04:51:39.7\n",
+                                # EPHEM/CLK/UNITS keep unit normalization and
+                                # convention resolution no-ops, so the failure
+                                # under test stays the PINT model build (this
+                                # par has no spindown component).
+                                "par_content": (
+                                    "PSR J0030+0451\n"
+                                    "RAJ 00:30:27.4\n"
+                                    "DECJ 04:51:39.7\n"
+                                    "EPHEM DE421\n"
+                                    "CLK TT(BIPM2015)\n"
+                                    "UNITS TDB\n"
+                                ),
                                 "timing_package": "tempo2",
                                 "tim_metadata": make_tim_metadata(timespan_days=1000.0),
                             }

--- a/tests/integration/test_legacy_comparison.py
+++ b/tests/integration/test_legacy_comparison.py
@@ -25,9 +25,30 @@ class TestLegacyComparison:
             return maybe_path.read_text(encoding="utf-8")
         return par_content
 
+    #: Explicit mixed-engine profile the current implementation must write
+    #: (feature_full_alignment_plan.md section 4.1).
+    MIXED_ENGINE_PROFILE = {
+        "UNITS": "TDB",
+        "T2CMETHOD": "IAU2000B",
+        "TIMEEPH": "FB90",
+        "DILATEFREQ": "N",
+        "CORRECT_TROPOSPHERE": "N",
+        "PLANET_SHAPIRO": "N",
+        "SWM": "0",
+    }
+
     def _assert_protocol_conventions(
-        self, par_content: str, label: str, engine_mix: bool
+        self,
+        par_content: str,
+        label: str,
+        engine_mix: bool,
+        full_profile: bool = False,
     ):
+        """Check the convention surface of a written par file.
+
+        ``full_profile`` asserts the complete mixed-engine profile; it applies
+        only to the current implementation, since the legacy module predates it.
+        """
         text = self._read_par_content(par_content)
         active_lines = []
         for raw in text.splitlines():
@@ -63,10 +84,27 @@ class TestLegacyComparison:
             assert (
                 keys["ECL"][0].upper() == "IERS2003"
             ), f"{label}: expected ECL IERS2003, found {' '.join(keys['ECL'])}"
+            # The obliquity change must be a coordinate transformation, so the
+            # ecliptic coordinates are re-emitted under PINT's canonical names.
+            assert (
+                "LAMBDA" not in keys and "BETA" not in keys
+            ), f"{label}: LAMBDA/BETA survived the numeric ecliptic transformation"
         elif has_equatorial and engine_mix:
             assert (
                 "ECL" not in keys
             ), f"{label}: equatorial astrometry should not include active ECL"
+
+        if not (engine_mix and full_profile):
+            return
+
+        for key, expected in self.MIXED_ENGINE_PROFILE.items():
+            assert key in keys, f"{label}: missing explicit {key} in mixed-engine par"
+            assert (
+                keys[key][0].upper() == expected.upper()
+            ), f"{label}: expected {key} {expected}, found {' '.join(keys[key])}"
+        assert (
+            "NO_SS_SHAPIRO" not in keys
+        ), f"{label}: NO_SS_SHAPIRO must be removed so whole-SS Shapiro stays on"
 
     def _prepare_legacy_input_files(
         self, pulsar_name, pta_data_releases, available_data_sets
@@ -185,6 +223,7 @@ class TestLegacyComparison:
             new_mp = new_module["MetaPulsarFactory"]().create_metapulsar(
                 file_data=filtered_file_data,
                 use_pulse_numbers="no",
+                exclude_from_consistent=(),
             )
 
             # Compare basic properties
@@ -486,6 +525,7 @@ class TestLegacyComparison:
             new_mp = new_module["MetaPulsarFactory"]().create_metapulsar(
                 file_data=filtered_file_data,
                 use_pulse_numbers="no",
+                exclude_from_consistent=(),
             )
 
             # Get design matrices
@@ -647,6 +687,7 @@ class TestLegacyComparison:
             new_mp = new_module["MetaPulsarFactory"]().create_metapulsar(
                 file_data=filtered_file_data,
                 use_pulse_numbers="no",
+                exclude_from_consistent=(),
             )
 
             # Get flags
@@ -759,6 +800,7 @@ class TestLegacyComparison:
             new_mp = new_module["MetaPulsarFactory"]().create_metapulsar(
                 file_data=filtered_file_data,
                 use_pulse_numbers="no",
+                exclude_from_consistent=(),
             )
 
             # Get intermediate par files (if available)
@@ -770,7 +812,7 @@ class TestLegacyComparison:
                     legacy_par_content, "legacy", engine_mix=engine_mix
                 )
                 self._assert_protocol_conventions(
-                    new_par_content, "new", engine_mix=engine_mix
+                    new_par_content, "new", engine_mix=engine_mix, full_profile=True
                 )
 
                 # Parse par files and compare key parameters
@@ -866,6 +908,7 @@ class TestLegacyComparison:
             new_mp = new_module["MetaPulsarFactory"]().create_metapulsar(
                 file_data=filtered_file_data,
                 use_pulse_numbers="no",
+                exclude_from_consistent=(),
             )
 
             # Get fitpars from both implementations

--- a/tests/integration/test_legacy_comparison.py
+++ b/tests/integration/test_legacy_comparison.py
@@ -461,10 +461,23 @@ class TestLegacyComparison:
 
     @pytest.mark.slow
     @pytest.mark.legacy_comparison
+    @pytest.mark.xfail(
+        reason=(
+            "Known divergence vs legacy: consistent rewrite aligns NE_SW "
+            "(NANOGrav SOLARN0 0 → stack value 4 when Tempo2 is present), "
+            "which shifts DM-family design-matrix columns past the relaxed "
+            "atol. exclude_from_consistent does not gate NE_SW; there is no "
+            "skip switch yet. Legacy comparison suite is scheduled for removal."
+        ),
+        strict=False,
+    )
     def test_design_matrix_construction(
         self, legacy_module, new_module, available_data_sets, test_pulsars
     ):
-        """Test design matrix construction equivalence."""
+        """Test design matrix construction equivalence.
+
+        Known failure: see xfail reason (NE_SW convention alignment vs legacy).
+        """
         if not available_data_sets:
             pytest.skip("No data available for testing")
 

--- a/tests/test_cross_engine_parity.py
+++ b/tests/test_cross_engine_parity.py
@@ -1,0 +1,201 @@
+"""Cross-engine residual parity for the two orthometric-Shapiro mechanisms.
+
+MetaPulsar's mixed-engine ``consistent`` profile makes two claims that only a
+real PINT-vs-Tempo2 residual comparison can check:
+
+* PINT must evaluate Freire & Wex (2010) Eq. 28 (``ell1h_shapiro="absorbed"``)
+  so an ELL1H/``T2`` ``H3``+``STIG`` model matches Tempo2's mode 1;
+* a shared ``H3``+``H4`` par must carry ``NHARM`` (Tempo2) as well as ``NHARMS``
+  (PINT), because Tempo2 otherwise falls back to ``nharm=4``.
+
+Protocol: idealize TOAs with PINT (residuals ~0 by construction), write them,
+then re-time with Tempo2 through libstempo and measure the residual RMS.
+
+Two deliberate choices keep the measurement sensitive to the binary model only:
+
+* TOAs are generated at the solar-system barycentre. Observatory TOAs carry a
+  ~270 ns floor from the two packages' independent clock-correction chains,
+  which is an external-realization difference this feature does not address.
+* ``DM 0`` removes a dispersion-versus-binary delay-ordering difference that
+  otherwise dominates at ~400 ns per light-second of ``A1`` per 10 pc/cm3.
+
+What remains is a ~5 ns control floor, so these tests assert *relative* parity
+against a matched non-Shapiro control. The absolute ~1 ns figures quoted in
+``consistency-pint-tempo2.md`` come from the round-trip suite in
+``paper/code/round-trip/parity_confirm/``, which uses real release TOAs.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from metapulsar.parameter_manager import AlignmentPolicy, ParameterManager
+
+libstempo = pytest.importorskip("libstempo")
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.requires_libstempo,
+    pytest.mark.skipif(
+        shutil.which("tempo2") is None, reason="tempo2 binary not available"
+    ),
+]
+
+#: RMS of the matched control (no orthometric Shapiro term) in ns; see module
+#: docstring for what sets it.
+CONTROL_FLOOR_NS = 15.0
+
+COMMON_BODY = """PSR J1600-3053
+EPHEM DE440
+CLOCK TT(BIPM2021)
+UNITS TDB
+ELONG 244.347677 1
+ELAT -10.071873 1
+ECL IERS2003
+POSEPOCH 55000
+F0 277.937 1
+F1 -7.3e-16 1
+PEPOCH 55000
+DM 0.0
+DMEPOCH 55000
+"""
+
+KEPLERIAN = """PB 14.348466 1
+A1 8.801653 1
+TASC 55000.0 1
+EPS1 1.7e-05 1
+EPS2 -9.1e-06 1
+"""
+
+CONTROL_PAR = COMMON_BODY + "BINARY ELL1\n" + KEPLERIAN
+H3_STIG_PAR = COMMON_BODY + "BINARY ELL1H\n" + KEPLERIAN + "H3 1.2e-07 1\nSTIG 0.72 1\n"
+H3_H4_PAR = COMMON_BODY + "BINARY ELL1H\n" + KEPLERIAN + "H3 1.2e-07 1\nH4 6.0e-08 1\n"
+
+
+def tempo2_rms_ns(par_path: Path, tmp_path: Path, ell1h_shapiro: str) -> float:
+    """Idealize TOAs with PINT, then measure Tempo2's residual RMS in ns."""
+    import astropy.units as u
+    from pint.models import get_model
+    from pint.simulation import make_fake_toas_uniform
+
+    model = get_model(str(par_path), allow_T2=True, ell1h_shapiro=ell1h_shapiro)
+    toas = make_fake_toas_uniform(
+        54500,
+        56500,
+        400,
+        model,
+        freq=1400 * u.MHz,
+        obs="ssb",
+        add_noise=False,
+    )
+    tim_path = tmp_path / f"{par_path.stem}_{ell1h_shapiro}.tim"
+    toas.write_TOA_file(str(tim_path), format="tempo2")
+
+    psr = libstempo.tempopulsar(
+        parfile=str(par_path), timfile=str(tim_path), dofit=False
+    )
+    residuals = np.asarray(
+        psr.residuals(updatebats=True, formresiduals=True, removemean=True),
+        dtype=float,
+    )
+    return float(np.std(residuals)) * 1e9
+
+
+def write_par(tmp_path: Path, name: str, text: str) -> Path:
+    path = tmp_path / f"{name}.par"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def align_mixed(tmp_path: Path, par_text: str) -> tuple[Path, str]:
+    """Run the mixed-engine consistent strategy on one par.
+
+    ``ne_sw=0`` pins the solar wind off: these TOAs sit at the barycentre, where
+    the observatory-Sun geometry that both engines' solar-wind terms need is
+    degenerate. The binary model is what this module measures.
+
+    Returns the tempo2 PTA's written par and the manager's ELL1H convention.
+    """
+    manager = ParameterManager(
+        file_data={
+            "t2": {"timing_package": "tempo2", "par_content": par_text},
+            "pint": {"timing_package": "pint", "par_content": par_text},
+        },
+        output_dir=tmp_path / "aligned",
+        pulsar_name="J1600-3053",
+        alignment_policy=AlignmentPolicy(ne_sw=0.0),
+    )
+    written = manager.make_parfiles_consistent()
+    return Path(written["t2"]), manager.ell1h_shapiro
+
+
+@pytest.fixture(scope="module")
+def control_rms(tmp_path_factory) -> float:
+    tmp_path = tmp_path_factory.mktemp("parity_control")
+    par = write_par(tmp_path, "control", CONTROL_PAR)
+    return tempo2_rms_ns(par, tmp_path, "absorbed")
+
+
+def test_control_floor_is_small(control_rms):
+    """Sanity check: without an orthometric term the two engines agree."""
+    assert control_rms < CONTROL_FLOOR_NS
+
+
+class TestOrthometricShapiroEvaluator:
+    """Section 7.8: absorbed vs full for H3+STIG."""
+
+    def test_absorbed_matches_tempo2(self, tmp_path, control_rms):
+        par = write_par(tmp_path, "h3stig", H3_STIG_PAR)
+        rms = tempo2_rms_ns(par, tmp_path, "absorbed")
+        # The Shapiro term adds nothing above the control floor.
+        assert rms == pytest.approx(control_rms, abs=1.0)
+
+    def test_pint_default_full_disagrees_with_tempo2(self, tmp_path, control_rms):
+        par = write_par(tmp_path, "h3stig", H3_STIG_PAR)
+        rms = tempo2_rms_ns(par, tmp_path, "full")
+        # Guard: the previous test would pass trivially if the evaluator choice
+        # did not matter.
+        assert rms > 20 * max(control_rms, 1.0)
+
+    def test_mixed_engine_alignment_selects_absorbed(self, tmp_path, control_rms):
+        aligned, mode = align_mixed(tmp_path, H3_STIG_PAR)
+        assert mode == "absorbed"
+        rms = tempo2_rms_ns(aligned, tmp_path, mode)
+        assert rms == pytest.approx(control_rms, abs=1.0)
+
+
+class TestOrthometricHarmonicCount:
+    """Section 7.7: dual NHARM + NHARMS >= 7 for H3+H4."""
+
+    def test_missing_harmonic_count_leaves_tempo2_at_its_default(
+        self, tmp_path, control_rms
+    ):
+        par = write_par(tmp_path, "h3h4_bare", H3_H4_PAR)
+        rms = tempo2_rms_ns(par, tmp_path, "absorbed")
+        assert rms > 3 * max(control_rms, 1.0)
+
+    def test_nharm_four_is_as_bad_as_omitting_it(self, tmp_path):
+        bare = tempo2_rms_ns(
+            write_par(tmp_path, "h3h4_bare", H3_H4_PAR), tmp_path, "absorbed"
+        )
+        four = tempo2_rms_ns(
+            write_par(tmp_path, "h3h4_four", H3_H4_PAR + "NHARM 4\nNHARMS 4\n"),
+            tmp_path,
+            "absorbed",
+        )
+        assert four == pytest.approx(bare, rel=1e-3)
+
+    def test_seven_harmonics_restores_parity(self, tmp_path, control_rms):
+        par = write_par(tmp_path, "h3h4_seven", H3_H4_PAR + "NHARM 7\nNHARMS 7\n")
+        rms = tempo2_rms_ns(par, tmp_path, "absorbed")
+        assert rms == pytest.approx(control_rms, abs=1.0)
+
+    def test_mixed_engine_alignment_restores_parity(self, tmp_path, control_rms):
+        aligned, mode = align_mixed(tmp_path, H3_H4_PAR)
+        assert "NHARM " in aligned.read_text(encoding="utf-8")
+        rms = tempo2_rms_ns(aligned, tmp_path, mode)
+        assert rms == pytest.approx(control_rms, abs=1.0)

--- a/tests/test_metapulsar_data_combination.py
+++ b/tests/test_metapulsar_data_combination.py
@@ -1,5 +1,8 @@
 """Tests for MetaPulsar data combination functionality."""
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 import numpy as np
 import pytest
 
@@ -96,3 +99,32 @@ class TestMetaPulsarDataCombination:
         slices = metapulsar._get_pta_slices()
         assert slices["small_pta"] == slice(0, 30)
         assert slices["large_pta"] == slice(30, 100)
+
+    def test_parameter_mapping_preserves_timing_package_identity(self):
+        metapulsar = object.__new__(MetaPulsar)
+        pint_model = MagicMock()
+        pint_model.as_parfile.return_value = "PSR J1857+0943\n"
+        tempo2_pulsar = MagicMock()
+        metapulsar._unpack_pulsar_data = MagicMock(
+            return_value=(
+                {"pint_pta": pint_model},
+                {},
+                {"tempo2_pta": tempo2_pulsar},
+            )
+        )
+        metapulsar._get_libstempo_parfile_content = MagicMock(
+            return_value="PSR J1857+0943\n"
+        )
+        metapulsar._setup_canonical_parameters = MagicMock()
+        metapulsar.combine_components = []
+        metapulsar.add_dm_derivatives = False
+        metapulsar.exclude_from_consistent = ()
+
+        mapping = SimpleNamespace(fitparameters={}, setparameters={})
+        with patch("metapulsar.metapulsar.ParameterManager") as manager_class:
+            manager_class.return_value.build_parameter_mappings.return_value = mapping
+            metapulsar._setup_parameters()
+
+        file_data = manager_class.call_args.kwargs["file_data"]
+        assert file_data["pint_pta"]["timing_package"] == "pint"
+        assert file_data["tempo2_pta"]["timing_package"] == "tempo2"

--- a/tests/test_metapulsar_factory.py
+++ b/tests/test_metapulsar_factory.py
@@ -405,6 +405,7 @@ class TestMetaPulsarFactory:
                 str(file_pairs["epta_dr2"][1]),
                 planets=True,
                 allow_T2=True,
+                ell1h_shapiro="full",
             )
 
     def test_create_pulsar_objects_tempo2(self):
@@ -864,3 +865,123 @@ class TestPtaSummary:
         captured = capsys.readouterr().out
         assert "150 TOAs" in captured
         assert "pn=mixed (100/150)" in captured
+
+
+class TestAlignmentPolicyForwarding:
+    """The factory's only new user-facing argument (section 5 of the plan)."""
+
+    def setup_method(self):
+        self.factory = MetaPulsarFactory()
+
+    @staticmethod
+    def _file_data(timing_packages=("pint",)):
+        body = (
+            "PSR J1857+0943\n"
+            "PEPOCH 55000\n"
+            "F0 186.494081 1\n"
+            "F1 -6.2e-16 1\n"
+            "RAJ 18:57:36.3937 1\n"
+            "DECJ +09:43:17.291 1\n"
+            "POSEPOCH 55000\n"
+            "DM 13.299 1\n"
+            "DMEPOCH 55000\n"
+            "EPHEM DE440\n"
+            "CLK TT(BIPM2019)\n"
+            "UNITS TDB\n"
+        )
+        return {
+            f"pta{index}": [
+                {
+                    "par": Path(f"/data/pta{index}/J1857+0943.par"),
+                    "tim": Path(f"/data/pta{index}/J1857+0943.tim"),
+                    "timing_package": package,
+                    "tim_metadata": make_tim_metadata(timespan_days=1000.0),
+                    "par_content": body,
+                }
+            ]
+            for index, package in enumerate(timing_packages)
+        }
+
+    def _run(self, mock_param_manager, **kwargs):
+        mock_manager_instance = Mock()
+        mock_manager_instance.make_parfiles_consistent.return_value = {}
+        mock_manager_instance.ell1h_shapiro = "full"
+        mock_param_manager.return_value = mock_manager_instance
+
+        with (
+            patch.object(self.factory, "_create_pulsar_objects") as mock_create,
+            patch("metapulsar.metapulsar_factory.MetaPulsar"),
+        ):
+            mock_create.return_value = {"pta0": Mock()}
+            self.factory.create_metapulsar(self._file_data(), **kwargs)
+        return mock_param_manager.call_args, mock_create.call_args
+
+    @patch("metapulsar.metapulsar_factory.ParameterManager")
+    def test_default_policy_is_none_and_manager_supplies_the_default(
+        self, mock_param_manager
+    ):
+        manager_call, _ = self._run(mock_param_manager)
+        assert manager_call[1]["alignment_policy"] is None
+
+    @patch("metapulsar.metapulsar_factory.ParameterManager")
+    def test_policy_is_forwarded_to_parameter_manager(self, mock_param_manager):
+        from metapulsar import AlignmentPolicy
+
+        policy = AlignmentPolicy(unsupported="error", ephem="DE421", ne_sw=4.0)
+        manager_call, _ = self._run(mock_param_manager, alignment_policy=policy)
+        assert manager_call[1]["alignment_policy"] is policy
+
+    def test_policy_with_composite_strategy_raises(self):
+        from metapulsar import AlignmentPolicy
+
+        with pytest.raises(ValueError, match="only applies to.*consistent"):
+            self.factory.create_metapulsar(
+                self._file_data(),
+                combination_strategy="composite",
+                alignment_policy=AlignmentPolicy(),
+            )
+
+    def test_composite_strategy_without_policy_is_accepted(self):
+        with (
+            patch.object(self.factory, "_create_pulsar_objects") as mock_create,
+            patch("metapulsar.metapulsar_factory.MetaPulsar"),
+        ):
+            mock_create.return_value = {"pta0": Mock()}
+            self.factory.create_metapulsar(
+                self._file_data(), combination_strategy="composite"
+            )
+        assert mock_create.call_args[1]["ell1h_shapiro"] == "full"
+
+    @patch("metapulsar.metapulsar_factory.ParameterManager")
+    def test_mixed_engine_consistent_materialization_uses_absorbed(
+        self, mock_param_manager
+    ):
+        mock_manager_instance = Mock()
+        mock_manager_instance.make_parfiles_consistent.return_value = {}
+        mock_manager_instance.ell1h_shapiro = "absorbed"
+        mock_param_manager.return_value = mock_manager_instance
+
+        with (
+            patch.object(self.factory, "_create_pulsar_objects") as mock_create,
+            patch("metapulsar.metapulsar_factory.MetaPulsar"),
+        ):
+            mock_create.return_value = {"pta0": Mock()}
+            self.factory.create_metapulsar(self._file_data(("tempo2", "pint")))
+
+        assert mock_create.call_args[1]["ell1h_shapiro"] == "absorbed"
+
+    @patch("metapulsar.metapulsar_factory.ParameterManager")
+    def test_pint_only_consistent_materialization_uses_full(self, mock_param_manager):
+        _, create_call = self._run(mock_param_manager)
+        assert create_call[1]["ell1h_shapiro"] == "full"
+
+    def test_module_level_helpers_accept_alignment_policy(self):
+        import inspect
+
+        from metapulsar.metapulsar_factory import (
+            create_all_metapulsars,
+            create_metapulsar,
+        )
+
+        for func in (create_metapulsar, create_all_metapulsars):
+            assert "alignment_policy" in inspect.signature(func).parameters

--- a/tests/test_parameter_manager.py
+++ b/tests/test_parameter_manager.py
@@ -15,6 +15,7 @@ from unittest.mock import Mock, patch, mock_open
 from pint.models.model_builder import parse_parfile
 
 from metapulsar.parameter_manager import (
+    AlignmentPolicy,
     ParameterManager,
     ParameterInconsistencyError,
     ParameterMapping,
@@ -27,6 +28,46 @@ from tests.helpers import make_tim_metadata
 
 # Mark all tests as slow
 pytestmark = pytest.mark.slow
+
+
+def align_conventions(parameter_manager, parfile_dicts, reference_dict):
+    """Run the two consistent-alignment steps in pipeline order.
+
+    ``_make_parameters_consistent`` numerically transforms ecliptic astrometry
+    first and only then applies the convention rules; tests that exercise the
+    convention surface must do the same.
+    """
+    parameter_manager._transform_ecliptic_for_all(parfile_dicts, reference_dict)
+    parameter_manager._apply_consistent_convention_rules(parfile_dicts, reference_dict)
+
+
+# Enough of a timing model that PINT can build one (needed for the numeric
+# ecliptic transformation), kept small on purpose.
+ECLIPTIC_BODY = (
+    "PSR J1600-3053\n"
+    "PEPOCH 55000\n"
+    "F0 277.937 1\n"
+    "F1 -7.3e-16 1\n"
+    "LAMBDA 244.347677 1\n"
+    "BETA -10.071873 1\n"
+    "PMLAMBDA -0.35 1\n"
+    "PMBETA -7.0 1\n"
+    "POSEPOCH 55000\n"
+    "DM 52.3 1\n"
+    "DMEPOCH 55000\n"
+)
+
+EQUATORIAL_BODY = (
+    "PSR J1857+0943\n"
+    "PEPOCH 55000\n"
+    "F0 186.494081 1\n"
+    "F1 -6.2e-16 1\n"
+    "RAJ 18:57:36.3937 1\n"
+    "DECJ +09:43:17.291 1\n"
+    "POSEPOCH 55000\n"
+    "DM 13.299 1\n"
+    "DMEPOCH 55000\n"
+)
 
 
 class TestParameterManager:
@@ -462,15 +503,12 @@ UNITS TDB
             )
 
     def test_apply_consistent_convention_rules_cross_engine_ecliptic(self):
-        """Cross-engine ecliptic pars force ECL IERS2003 and remove T2CMETHOD TEMPO."""
+        """Cross-engine ecliptic pars land on IERS2003 with explicit IAU2000B."""
         file_data = {
             "EPTA": {
                 "timing_package": "tempo2",
                 "par_content": (
-                    "PSR J1600-3053\n"
-                    "LAMBDA 244.347\n"
-                    "BETA -10.07\n"
-                    "ECL IERS2010\n"
+                    ECLIPTIC_BODY + "ECL IERS2010\n"
                     "T2CMETHOD TEMPO\n"
                     "EPHEM DE436\n"
                     "CLOCK TT(BIPM2015)\n"
@@ -480,10 +518,7 @@ UNITS TDB
             "PPTA": {
                 "timing_package": "pint",
                 "par_content": (
-                    "PSR J1600-3053\n"
-                    "LAMBDA 244.347\n"
-                    "BETA -10.07\n"
-                    "ECL IERS2010\n"
+                    ECLIPTIC_BODY + "ECL IERS2010\n"
                     "T2CMETHOD TEMPO\n"
                     "EPHEM DE440\n"
                     "CLK TT(BIPM2021)\n"
@@ -495,14 +530,12 @@ UNITS TDB
         parfile_dicts = parameter_manager._parse_parfiles()
         reference_dict = parfile_dicts["EPTA"]
 
-        parameter_manager._apply_consistent_convention_rules(
-            parfile_dicts, reference_dict
-        )
+        align_conventions(parameter_manager, parfile_dicts, reference_dict)
 
         for _, pd in parfile_dicts.items():
             assert pd["UNITS"] == ["TDB"]
             assert pd["ECL"] == ["IERS2003"]
-            assert "T2CMETHOD" not in pd
+            assert pd["T2CMETHOD"] == ["IAU2000B"]
             assert pd["EPHEM"] == ["DE436"]
             clock_value = pd["CLOCK"] if "CLOCK" in pd else pd["CLK"]
             assert clock_value == ["TT(BIPM2015)"]
@@ -515,10 +548,7 @@ UNITS TDB
             "EPTA": {
                 "timing_package": "pint",
                 "par_content": (
-                    "PSR J1857+0943\n"
-                    "RAJ 18:57:36.3937\n"
-                    "DECJ +09:43:17.291\n"
-                    "ECL IERS2010\n"
+                    EQUATORIAL_BODY + "ECL IERS2010\n"
                     "T2CMETHOD TEMPO\n"
                     "EPHEM DE440\n"
                     "CLOCK TT(BIPM2021)\n"
@@ -528,10 +558,7 @@ UNITS TDB
             "PPTA": {
                 "timing_package": "tempo2",
                 "par_content": (
-                    "PSR J1857+0943\n"
-                    "RAJ 18:57:36.3937\n"
-                    "DECJ +09:43:17.291\n"
-                    "T2CMETHOD TEMPO\n"
+                    EQUATORIAL_BODY + "T2CMETHOD TEMPO\n"
                     "EPHEM DE436\n"
                     "CLK TT(BIPM2015)\n"
                     "UNITS TDB\n"
@@ -543,14 +570,12 @@ UNITS TDB
         reference_dict = parfile_dicts["EPTA"]
 
         with patch.object(parameter_manager.logger, "warning") as mock_warning:
-            parameter_manager._apply_consistent_convention_rules(
-                parfile_dicts, reference_dict
-            )
+            align_conventions(parameter_manager, parfile_dicts, reference_dict)
 
         for _, pd in parfile_dicts.items():
             assert pd["UNITS"] == ["TDB"]
             assert "ECL" not in pd
-            assert "T2CMETHOD" not in pd
+            assert pd["T2CMETHOD"] == ["IAU2000B"]
         assert mock_warning.call_count == 2
 
     def test_apply_consistent_convention_rules_pint_only_aligns_missing_ecl_to_iers2010(
@@ -560,10 +585,7 @@ UNITS TDB
             "EPTA": {
                 "timing_package": "pint",
                 "par_content": (
-                    "PSR J1600-3053\n"
-                    "LAMBDA 244.347\n"
-                    "BETA -10.07\n"
-                    "ECL IERS2010\n"
+                    ECLIPTIC_BODY + "ECL IERS2010\n"
                     "EPHEM DE440\n"
                     "CLOCK TT(BIPM2021)\n"
                     "UNITS TDB\n"
@@ -572,12 +594,7 @@ UNITS TDB
             "PPTA": {
                 "timing_package": "pint",
                 "par_content": (
-                    "PSR J1600-3053\n"
-                    "LAMBDA 244.347\n"
-                    "BETA -10.07\n"
-                    "EPHEM DE436\n"
-                    "CLK TT(BIPM2015)\n"
-                    "UNITS TDB\n"
+                    ECLIPTIC_BODY + "EPHEM DE436\nCLK TT(BIPM2015)\nUNITS TDB\n"
                 ),
             },
         }
@@ -586,14 +603,16 @@ UNITS TDB
         reference_dict = parfile_dicts["EPTA"]
 
         with patch.object(parameter_manager.logger, "warning") as mock_warning:
-            parameter_manager._apply_consistent_convention_rules(
-                parfile_dicts, reference_dict
-            )
+            align_conventions(parameter_manager, parfile_dicts, reference_dict)
 
         assert parfile_dicts["EPTA"]["ECL"] == ["IERS2010"]
         assert parfile_dicts["PPTA"]["ECL"] == ["IERS2010"]
+        # PINT-only stacks keep the thinner profile: no forced T2CMETHOD and no
+        # forced troposphere / planetary-Shapiro switches.
         assert "T2CMETHOD" not in parfile_dicts["EPTA"]
         assert "T2CMETHOD" not in parfile_dicts["PPTA"]
+        assert "CORRECT_TROPOSPHERE" not in parfile_dicts["EPTA"]
+        assert "TIMEEPH" not in parfile_dicts["EPTA"]
         assert mock_warning.call_count == 0
 
     def test_apply_consistent_convention_rules_tempo2_only_preserves_shared_t2cmethod(
@@ -603,10 +622,7 @@ UNITS TDB
             "EPTA": {
                 "timing_package": "tempo2",
                 "par_content": (
-                    "PSR J1600-3053\n"
-                    "LAMBDA 244.347\n"
-                    "BETA -10.07\n"
-                    "ECL IERS2010\n"
+                    ECLIPTIC_BODY + "ECL IERS2010\n"
                     "T2CMETHOD TEMPO\n"
                     "EPHEM DE436\n"
                     "CLOCK TT(BIPM2015)\n"
@@ -616,10 +632,7 @@ UNITS TDB
             "PPTA": {
                 "timing_package": "tempo2",
                 "par_content": (
-                    "PSR J1600-3053\n"
-                    "LAMBDA 244.347\n"
-                    "BETA -10.07\n"
-                    "ECL IERS2010\n"
+                    ECLIPTIC_BODY + "ECL IERS2010\n"
                     "T2CMETHOD TEMPO\n"
                     "EPHEM DE440\n"
                     "CLK TT(BIPM2021)\n"
@@ -631,9 +644,7 @@ UNITS TDB
         parfile_dicts = parameter_manager._parse_parfiles()
         reference_dict = parfile_dicts["EPTA"]
 
-        parameter_manager._apply_consistent_convention_rules(
-            parfile_dicts, reference_dict
-        )
+        align_conventions(parameter_manager, parfile_dicts, reference_dict)
 
         for pd in parfile_dicts.values():
             assert pd["ECL"] == ["IERS2010"]
@@ -646,10 +657,7 @@ UNITS TDB
             "EPTA": {
                 "timing_package": "tempo2",
                 "par_content": (
-                    "PSR J1600-3053\n"
-                    "LAMBDA 244.347\n"
-                    "BETA -10.07\n"
-                    "ECL IERS2010\n"
+                    ECLIPTIC_BODY + "ECL IERS2010\n"
                     "T2CMETHOD TEMPO\n"
                     "EPHEM DE436\n"
                     "CLOCK TT(BIPM2015)\n"
@@ -659,10 +667,7 @@ UNITS TDB
             "PPTA": {
                 "timing_package": "tempo2",
                 "par_content": (
-                    "PSR J1600-3053\n"
-                    "LAMBDA 244.347\n"
-                    "BETA -10.07\n"
-                    "ECL IERS2003\n"
+                    ECLIPTIC_BODY + "ECL IERS2003\n"
                     "T2CMETHOD IAU2000B\n"
                     "EPHEM DE440\n"
                     "CLK TT(BIPM2021)\n"
@@ -674,9 +679,7 @@ UNITS TDB
         parfile_dicts = parameter_manager._parse_parfiles()
         reference_dict = parfile_dicts["EPTA"]
 
-        parameter_manager._apply_consistent_convention_rules(
-            parfile_dicts, reference_dict
-        )
+        align_conventions(parameter_manager, parfile_dicts, reference_dict)
 
         assert parfile_dicts["EPTA"]["ECL"] == ["IERS2003"]
         assert parfile_dicts["PPTA"]["ECL"] == ["IERS2003"]
@@ -1016,14 +1019,15 @@ UNITS TDB
             )
 
     def test_apply_consistent_convention_rules_pint_only_elong_elat_aliases(self):
+        # LAMBDA/BETA -> ELONG/ELAT, and PMLAMBDA/PMBETA -> PMELONG/PMELAT
+        elong_body = ECLIPTIC_BODY.replace("LAMBDA ", "ELONG ").replace(
+            "BETA ", "ELAT "
+        )
         file_data = {
             "EPTA": {
                 "timing_package": "pint",
                 "par_content": (
-                    "PSR J1600-3053\n"
-                    "ELONG 244.347\n"
-                    "ELAT -10.07\n"
-                    "ECL IERS2010\n"
+                    elong_body + "ECL IERS2010\n"
                     "EPHEM DE440\n"
                     "CLOCK TT(BIPM2021)\n"
                     "UNITS TDB\n"
@@ -1032,12 +1036,7 @@ UNITS TDB
             "PPTA": {
                 "timing_package": "pint",
                 "par_content": (
-                    "PSR J1600-3053\n"
-                    "ELONG 244.347\n"
-                    "ELAT -10.07\n"
-                    "EPHEM DE436\n"
-                    "CLK TT(BIPM2015)\n"
-                    "UNITS TDB\n"
+                    elong_body + "EPHEM DE436\nCLK TT(BIPM2015)\nUNITS TDB\n"
                 ),
             },
         }
@@ -1045,9 +1044,7 @@ UNITS TDB
         parfile_dicts = parameter_manager._parse_parfiles()
         reference_dict = parfile_dicts["EPTA"]
 
-        parameter_manager._apply_consistent_convention_rules(
-            parfile_dicts, reference_dict
-        )
+        align_conventions(parameter_manager, parfile_dicts, reference_dict)
 
         assert parfile_dicts["EPTA"]["ECL"] == ["IERS2010"]
         assert parfile_dicts["PPTA"]["ECL"] == ["IERS2010"]
@@ -1255,17 +1252,11 @@ UNITS TDB
         file_data = {
             "NG": {
                 "timing_package": "pint",
-                "par_content": (
-                    "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\n"
-                    "F1 -6.2e-16\nUNITS TDB\n"
-                ),
+                "par_content": EQUATORIAL_BODY + "UNITS TDB\n",
             },
             "EPTA": {
                 "timing_package": "tempo2",
-                "par_content": (
-                    "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\n"
-                    "F1 -6.2e-16\nUNITS TDB\n"
-                ),
+                "par_content": EQUATORIAL_BODY + "UNITS TDB\n",
             },
         }
         parameter_manager = ParameterManager(
@@ -1367,3 +1358,1071 @@ UNITS TDB
             assert "SOLARN0" not in content, f"{pta_name}: alias survived rewrite"
             model = create_pint_model(content)  # must not raise
             assert float(model.NE_SW.value) == pytest.approx(4.0)
+
+
+# ===================================================================
+# Complete cross-engine alignment: policy, stripping, transformations
+# ===================================================================
+
+
+def _cross_engine_file_data(
+    reference_extra: str = "",
+    other_extra: str = "",
+    body: str = EQUATORIAL_BODY,
+    reference_package: str = "tempo2",
+    other_package: str = "pint",
+):
+    """Two-PTA file data with a tempo2 reference and a PINT partner."""
+    return {
+        "EPTA": {
+            "timing_package": reference_package,
+            "par_content": (
+                body + "EPHEM DE440\nCLK TT(BIPM2019)\nUNITS TDB\n" + reference_extra
+            ),
+        },
+        "NG": {
+            "timing_package": other_package,
+            "par_content": (
+                body + "EPHEM DE436\nCLOCK TT(BIPM2015)\nUNITS TDB\n" + other_extra
+            ),
+        },
+    }
+
+
+def _prepared_dicts(parameter_manager):
+    """Parse and run the common-surface preparation step."""
+    parfile_dicts = parameter_manager._parse_parfiles()
+    parameter_manager._prepare_common_surface(parfile_dicts)
+    return parfile_dicts
+
+
+class TestAlignmentPolicy:
+    """The one new public knob for the consistent strategy."""
+
+    def test_defaults(self):
+        policy = AlignmentPolicy()
+        assert policy.unsupported == "strip"
+        assert policy.ephem is None
+        assert policy.clock is None
+        assert policy.bipm_version is None
+        assert policy.ne_sw is None
+
+    def test_rejects_unknown_unsupported_policy(self):
+        with pytest.raises(ValueError, match="strip.*error"):
+            AlignmentPolicy(unsupported="keep")
+
+    def test_rejects_negative_ne_sw(self):
+        with pytest.raises(ValueError, match="ne_sw must be non-negative"):
+            AlignmentPolicy(ne_sw=-1.0)
+
+    def test_is_frozen(self):
+        policy = AlignmentPolicy()
+        with pytest.raises(Exception):
+            policy.unsupported = "error"
+
+    def test_parameter_manager_defaults_to_strip(self):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        assert pm.alignment_policy == AlignmentPolicy()
+
+    def test_exported_from_package_root(self):
+        import metapulsar
+
+        assert metapulsar.AlignmentPolicy is AlignmentPolicy
+
+
+class TestTempo1Expansion:
+    """Section 6.1: the aggregate TEMPO1 switch becomes six explicit states."""
+
+    def test_absent_tempo1_is_a_no_op(self):
+        from metapulsar.parameter_manager import expand_tempo1
+
+        par = {"PSR": ["J1857+0943"], "UNITS": ["TDB"]}
+        assert expand_tempo1(par) == []
+        assert par == {"PSR": ["J1857+0943"], "UNITS": ["TDB"]}
+
+    def test_tempo1_is_removed_and_expanded(self):
+        from metapulsar.parameter_manager import TEMPO1_DEFAULTS, expand_tempo1
+
+        par = {"PSR": ["J1857+0943"], "TEMPO1": ["1"]}
+        filled = expand_tempo1(par)
+
+        assert "TEMPO1" not in par
+        assert set(filled) == set(TEMPO1_DEFAULTS)
+        for key, value in TEMPO1_DEFAULTS.items():
+            assert par[key] == value
+
+    def test_explicit_values_win_over_tempo1_defaults(self):
+        from metapulsar.parameter_manager import expand_tempo1
+
+        par = {"TEMPO1": ["1"], "T2CMETHOD": ["IAU2000B"], "UNITS": ["TCB"]}
+        filled = expand_tempo1(par)
+
+        assert "T2CMETHOD" not in filled
+        assert par["T2CMETHOD"] == ["IAU2000B"]
+        assert par["UNITS"] == ["TCB"]
+        assert par["TIMEEPH"] == ["FB90"]
+
+    def test_pipeline_expands_tempo1_for_multi_pta(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(reference_extra="TEMPO1\n")
+        )
+        parfile_dicts = _prepared_dicts(pm)
+
+        assert "TEMPO1" not in parfile_dicts["EPTA"]
+        assert parfile_dicts["EPTA"]["TIMEEPH"] == ["FB90"]
+        assert parfile_dicts["EPTA"]["DILATEFREQ"] == ["N"]
+
+
+class TestUnsupportedFamilyMatchers:
+    """Section 6.2-6.4: anchored matchers, never generic prefix stripping."""
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "EPHEM_FILE",
+            "EPH_FILE",
+            "EOP_FILE",
+            "CLK_CORR_CHAIN",
+            "NE_SW_SIN",
+            "NE_SW_IFUNC",
+            "_NE_SW",
+            "DMMODEL",
+            "_DM",
+            "_CM",
+            "DMOFF",
+            "SATJUMP",
+            "PMRA2",
+            "PMDEC2",
+            "PMLAMBDA2",
+            "PMBETA2",
+            "PMELONG2",
+            "PMELAT2",
+            "PMRV",
+            "DSHK",
+            "D_AOP",
+            "STEL_DX",
+            "TELEPOCH",
+            "TELX",
+            "TELY",
+            "TELZ",
+            "TEL_DX",
+            "TEL_DX1",
+            "TEL_DX_1",
+        ],
+    )
+    def test_pint_unsafe_positives(self, key):
+        from metapulsar.parameter_manager import _is_pint_unsafe
+
+        assert _is_pint_unsafe(key)
+
+    @pytest.mark.parametrize(
+        "key", ["NE_SW", "DM", "CM", "DMX_0001", "PMRA", "PMDEC", "TELESCOPE"]
+    )
+    def test_pint_unsafe_negatives(self, key):
+        from metapulsar.parameter_manager import _is_pint_unsafe
+
+        assert not _is_pint_unsafe(key)
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "SWP",
+            "SWEPOCH",
+            "VLBIAX",
+            "VLBIAY",
+            "VLBIAZ",
+            "NE_SW1",
+            "NE_SW2",
+            "NE_SW12",
+            "SWXDM_0001",
+            "SWXP_0001",
+            "SWXR1_0001",
+            "SWXR2_0001",
+            "DMWXEPOCH",
+            "DMWXFREQ_0001",
+            "DMWXSIN_0001",
+            "DMWXCOS_0001",
+        ],
+    )
+    def test_tempo2_unsafe_positives(self, key):
+        from metapulsar.parameter_manager import _is_tempo2_unsafe
+
+        assert _is_tempo2_unsafe(key)
+
+    @pytest.mark.parametrize(
+        "key", ["NE_SW", "NE_SW_SIN", "SWM", "DM", "DMX_0001", "DMJUMP"]
+    )
+    def test_tempo2_unsafe_negatives(self, key):
+        from metapulsar.parameter_manager import _is_tempo2_unsafe
+
+        assert not _is_tempo2_unsafe(key)
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "WAVE1",
+            "WAVE12",
+            "WAVEEPOCH",
+            "WAVE_OM",
+            "WXEPOCH",
+            "WXFREQ_0001",
+            "WXSIN_0001",
+            "WXCOS_0001",
+            "IFUNC1",
+            "SIFUNC",
+            "CM",
+            "CM1",
+            "CM2",
+            "CMEPOCH",
+            "CMX_0001",
+            "CHROMX_0001",
+            "CMWXEPOCH",
+            "CMWXFREQ_0001",
+            "GLEP_1",
+            "GLPH_1",
+            "GLF0_1",
+            "GLF1_1",
+            "GLF2_1",
+            "GLF0D_1",
+            "GLTD_1",
+            "GLF0D2_1",
+            "GLTD2_1",
+            "DMASSPLANET5",
+            "DPHASEPLANET3",
+            "EXPEP_1",
+            "EXPPH_1",
+            "EXPTAU_1",
+            "EXPINDEX_1",
+            "GAUSEP_1",
+            "GAUSAMP_1",
+            "GAUSSIG_1",
+            "GAUSINDEX_1",
+            "EXPDIPEP_1",
+            "EXPDIPAMP_1",
+            "PWSTART_1",
+            "PWF0_1",
+            "CHROMGAUSS_FREF",
+            "TNDMEVENT",
+            "TNSHAPELETEVENT",
+        ],
+    )
+    def test_mixed_unsafe_positives(self, key):
+        from metapulsar.parameter_manager import _is_mixed_unsafe
+
+        assert _is_mixed_unsafe(key)
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            # Noise hyperparameters are out of scope and must never be matched.
+            "EFAC",
+            "EQUAD",
+            "ECORR",
+            "T2EFAC",
+            "T2EQUAD",
+            "TNEF",
+            "TNEQ",
+            "TNECORR",
+            "TNREDAMP",
+            "TNREDGAM",
+            "TNDMAMP",
+            "TNDMGAM",
+            "TNCHROMAMP",
+            "TNCHROMGAM",
+            "RNAMP",
+            "RNIDX",
+            "DMEFAC",
+            "DMJUMP",
+            # Ordinary deterministic terms that stay.
+            "DM",
+            "DM1",
+            "DM2",
+            "DMX_0001",
+            "DMEPOCH",
+            "JUMP",
+            "FD1",
+            "FD2",
+            "FDJUMP1",
+            "FDJUMPDM",
+            "FDDC",
+            "FDDI",
+            "TZRMJD",
+            "TZRSITE",
+            "TZRFRQ",
+            "NE_SW",
+            "PX",
+            "WAVE",
+            "GLEP",
+            "CMWX",
+        ],
+    )
+    def test_mixed_unsafe_negatives(self, key):
+        from metapulsar.parameter_manager import _is_mixed_unsafe
+
+        assert not _is_mixed_unsafe(key)
+
+
+class TestUnsupportedPolicy:
+    """Section 6: default strip with a warning, or a hard error."""
+
+    UNSUPPORTED_EXTRA = (
+        "DMMODEL 1\n"
+        "CONSTRAIN DMMODEL\n"
+        "CONSTRAIN IFUNC\n"
+        "EPHEM_FILE DE440.bsp\n"
+        "GLEP_1 55000\n"
+        "WAVE1 1e-8 1e-8\n"
+        "CMX_0001 0.1\n"
+        "DMASSPLANET5 1e-9\n"
+        "PMRA2 0.1\n"
+        "TELX 0.1\n"
+    )
+    PINT_EXTRA = "NE_SW1 0.1\nSWX_0001 1.0\nDMWXFREQ_0001 0.01\nSWEPOCH 55000\n"
+    NOISE_EXTRA = (
+        "TNRedAmp -14.0\n"
+        "TNRedGam 3.0\n"
+        "EFAC -f L-wide 1.1\n"
+        "ECORR -f L-wide 0.5\n"
+        "DMJUMP -fe Rcvr 0.01\n"
+    )
+    LOCAL_EXTRA = (
+        "JUMP -fe Rcvr_800 1.2e-6 1\n"
+        "FD1 1.0e-5 1\n"
+        "FDJUMP1 1.0e-6 1\n"
+        "FDDC 1.0\n"
+        "FDDI 2.0\n"
+        "TZRMJD 55000\n"
+        "TZRSITE ao\n"
+        "TZRFRQ 1400.0\n"
+    )
+
+    def _manager(self, policy=None):
+        return ParameterManager(
+            file_data=_cross_engine_file_data(
+                reference_extra=self.UNSUPPORTED_EXTRA
+                + self.NOISE_EXTRA
+                + self.LOCAL_EXTRA,
+                other_extra=self.PINT_EXTRA + self.NOISE_EXTRA,
+            ),
+            alignment_policy=policy,
+        )
+
+    def test_default_policy_strips_every_family(self):
+        pm = self._manager()
+        parfile_dicts = _prepared_dicts(pm)
+
+        reference = parfile_dicts["EPTA"]
+        for key in (
+            "DMMODEL",
+            "EPHEM_FILE",
+            "GLEP_1",
+            "WAVE1",
+            "CMX_0001",
+            "DMASSPLANET5",
+            "PMRA2",
+            "TELX",
+        ):
+            assert key not in reference, f"{key} survived the strip policy"
+
+        other = parfile_dicts["NG"]
+        for key in ("NE_SW1", "SWX_0001", "DMWXFREQ_0001", "SWEPOCH"):
+            assert key not in other, f"{key} survived the strip policy"
+
+    def test_default_policy_keeps_noise_hyperparameters(self):
+        pm = self._manager()
+        parfile_dicts = _prepared_dicts(pm)
+
+        for pta in ("EPTA", "NG"):
+            par = parfile_dicts[pta]
+            for key in ("TNREDAMP", "TNREDGAM", "EFAC", "ECORR", "DMJUMP"):
+                assert key in par, f"{pta}: noise key {key} was stripped"
+
+    def test_default_policy_keeps_pta_local_deterministic_terms(self):
+        pm = self._manager()
+        parfile_dicts = _prepared_dicts(pm)
+
+        par = parfile_dicts["EPTA"]
+        for key in (
+            "JUMP",
+            "FD1",
+            "FDJUMP1",
+            "FDDC",
+            "FDDI",
+            "TZRMJD",
+            "TZRSITE",
+            "TZRFRQ",
+        ):
+            assert key in par, f"PTA-local key {key} was stripped"
+
+    def test_dmmodel_constraints_are_filtered_without_touching_others(self):
+        pm = self._manager()
+        parfile_dicts = _prepared_dicts(pm)
+
+        assert parfile_dicts["EPTA"]["CONSTRAIN"] == ["IFUNC"]
+
+    def test_strip_warning_names_pta_and_removed_keys(self, caplog):
+        pm = self._manager()
+        with caplog.at_level(logging.WARNING):
+            _prepared_dicts(pm)
+
+        messages = [r.message for r in caplog.records if "stripped" in r.message]
+        assert any("PTA EPTA" in m and "DMMODEL" in m for m in messages)
+        assert any("PTA NG" in m and "SWX_0001" in m for m in messages)
+
+    def test_error_policy_reports_all_offending_keys(self):
+        pm = self._manager(AlignmentPolicy(unsupported="error"))
+        parfile_dicts = pm._parse_parfiles()
+
+        with pytest.raises(ValueError) as excinfo:
+            pm._prepare_common_surface(parfile_dicts)
+
+        message = str(excinfo.value)
+        assert "PTA EPTA" in message
+        for key in ("DMMODEL", "EPHEM_FILE", "GLEP_1", "WAVE1", "TELX"):
+            assert key in message
+        assert "CONSTRAIN DMMODEL" in message
+
+    def test_single_pta_surface_is_not_rewritten(self):
+        pm = ParameterManager(
+            file_data={
+                "EPTA": {
+                    "timing_package": "tempo2",
+                    "par_content": (
+                        EQUATORIAL_BODY
+                        + "EPHEM DE440\nCLK TT(BIPM2019)\nUNITS TDB\n"
+                        + self.UNSUPPORTED_EXTRA
+                    ),
+                }
+            }
+        )
+        parfile_dicts = _prepared_dicts(pm)
+
+        assert parfile_dicts["EPTA"]["DMMODEL"] == ["1"]
+        assert "GLEP_1" in parfile_dicts["EPTA"]
+        assert parfile_dicts["EPTA"]["CONSTRAIN"] == ["DMMODEL", "IFUNC"]
+
+
+class TestSolarGeometryNormalization:
+    """Section 6.2/6.3: IPM 0 and SWM 1 are value-dependent violations."""
+
+    def test_ipm_zero_is_stripped_and_normalized_on_tempo2_output(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(reference_extra="IPM 0\n")
+        )
+        parfile_dicts = _prepared_dicts(pm)
+        assert "IPM" not in parfile_dicts["EPTA"]
+
+        pm._apply_explicit_conventions(parfile_dicts)
+        assert parfile_dicts["EPTA"]["IPM"] == ["1"]
+        assert "IPM" not in parfile_dicts["NG"]
+
+    def test_absent_ipm_still_becomes_explicit_on_tempo2_output(self):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        parfile_dicts = _prepared_dicts(pm)
+
+        pm._apply_explicit_conventions(parfile_dicts)
+        assert parfile_dicts["EPTA"]["IPM"] == ["1"]
+        assert "IPM" not in parfile_dicts["NG"]
+
+    def test_ipm_zero_is_a_violation_under_error_policy(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(reference_extra="IPM 0\n"),
+            alignment_policy=AlignmentPolicy(unsupported="error"),
+        )
+        with pytest.raises(ValueError, match="IPM"):
+            pm._prepare_common_surface(pm._parse_parfiles())
+
+    def test_swm_one_is_stripped_and_normalized_to_zero(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(other_extra="SWM 1\nSWP 2.0\n")
+        )
+        parfile_dicts = _prepared_dicts(pm)
+        assert "SWM" not in parfile_dicts["NG"]
+        assert "SWP" not in parfile_dicts["NG"]
+
+        pm._apply_explicit_conventions(parfile_dicts)
+        assert parfile_dicts["NG"]["SWM"] == ["0"]
+        assert parfile_dicts["EPTA"]["SWM"] == ["0"]
+
+    def test_swm_one_is_a_violation_under_error_policy(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(other_extra="SWM 1\n"),
+            alignment_policy=AlignmentPolicy(unsupported="error"),
+        )
+        with pytest.raises(ValueError, match="SWM"):
+            pm._prepare_common_surface(pm._parse_parfiles())
+
+    def test_swm_zero_is_not_a_violation(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(other_extra="SWM 0\n"),
+            alignment_policy=AlignmentPolicy(unsupported="error"),
+        )
+        pm._prepare_common_surface(pm._parse_parfiles())  # must not raise
+
+    def test_policy_ne_sw_overrides_reference_value(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(reference_extra="NE_SW 4\n"),
+            alignment_policy=AlignmentPolicy(ne_sw=7.5),
+        )
+        parfile_dicts = pm._parse_parfiles()
+        pm._align_ne_sw_convention(parfile_dicts, parfile_dicts["EPTA"])
+
+        assert parfile_dicts["EPTA"]["NE_SW"] == ["7.5 0"]
+        assert parfile_dicts["NG"]["NE_SW"] == ["7.5 0"]
+
+
+class TestUnitNormalization:
+    """Section 7.3: timescale policy is gated by PTA count and engine mix."""
+
+    def test_all_tdb_collection_is_returned_unchanged(self):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        contents = {pta: data["par_content"] for pta, data in pm.file_data.items()}
+        assert pm._convert_units_if_needed(contents) == contents
+
+    def test_mixed_engine_all_tcb_collection_is_converted(self):
+        tcb_body = EQUATORIAL_BODY + "EPHEM DE440\nCLK TT(BIPM2019)\nUNITS TCB\n"
+        pm = ParameterManager(
+            file_data={
+                "A": {"timing_package": "pint", "par_content": tcb_body},
+                "B": {"timing_package": "tempo2", "par_content": tcb_body},
+            }
+        )
+        contents = {pta: data["par_content"] for pta, data in pm.file_data.items()}
+
+        def as_tdb(text):
+            return text.replace("UNITS TCB", "UNITS TDB")
+
+        with (
+            patch.object(pm, "_convert_pint_to_tdb", side_effect=as_tdb),
+            patch.object(pm, "_convert_tempo2_to_tdb", side_effect=as_tdb),
+        ):
+            converted = pm._convert_units_if_needed(contents)
+
+        for pta, text in converted.items():
+            parsed = parse_parfile(StringIO(text))
+            assert parsed["UNITS"] == ["TDB"], f"{pta} not converted to TDB"
+            assert text != contents[pta]
+
+    @pytest.mark.parametrize("package", ["pint", "tempo2"])
+    def test_single_engine_all_tcb_collection_is_preserved(self, package):
+        tcb_body = EQUATORIAL_BODY + "EPHEM DE440\nCLK TT(BIPM2019)\nUNITS TCB\n"
+        pm = ParameterManager(
+            file_data={
+                "A": {"timing_package": package, "par_content": tcb_body},
+                "B": {"timing_package": package, "par_content": tcb_body},
+            }
+        )
+        contents = {pta: data["par_content"] for pta, data in pm.file_data.items()}
+
+        assert pm._convert_units_if_needed(contents) == contents
+
+        parfile_dicts = {
+            pta: parse_parfile(StringIO(text)) for pta, text in contents.items()
+        }
+        pm._apply_explicit_conventions(parfile_dicts)
+        assert {par["UNITS"][0] for par in parfile_dicts.values()} == {"TCB"}
+
+    def test_single_pta_tcb_is_preserved(self):
+        text = EQUATORIAL_BODY + "EPHEM DE440\nCLK TT(BIPM2019)\nUNITS TCB\n"
+        pm = ParameterManager(
+            file_data={
+                "A": {"timing_package": "tempo2", "par_content": text},
+            }
+        )
+
+        assert pm._convert_units_if_needed({"A": text}) == {"A": text}
+
+    def test_mixed_collection_converts_only_the_tcb_input(self):
+        pm = ParameterManager(
+            file_data={
+                "A": {
+                    "timing_package": "pint",
+                    "par_content": EQUATORIAL_BODY
+                    + "EPHEM DE440\nCLK TT(BIPM2019)\nUNITS TDB\n",
+                },
+                "B": {
+                    "timing_package": "pint",
+                    "par_content": EQUATORIAL_BODY
+                    + "EPHEM DE440\nCLK TT(BIPM2019)\nUNITS TCB\n",
+                },
+            }
+        )
+        contents = {pta: data["par_content"] for pta, data in pm.file_data.items()}
+
+        converted = pm._convert_units_if_needed(contents)
+
+        assert converted["A"] == contents["A"]
+        assert parse_parfile(StringIO(converted["B"]))["UNITS"] == ["TDB"]
+
+    def test_assert_explicit_tdb_rejects_non_tdb_output(self):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        with pytest.raises(RuntimeError, match="explicit\n?.*UNITS TDB"):
+            pm._assert_explicit_tdb("A", "PSR J1857+0943\nUNITS TCB\n")
+
+
+class TestEclipticTransformation:
+    """Section 7.4: a coordinate rotation, never a label rewrite."""
+
+    ECL_BODY = ECLIPTIC_BODY + "EPHEM DE440\nCLK TT(BIPM2019)\nUNITS TDB\n"
+
+    def _icrs(self, par_dict, epoch):
+        from astropy.coordinates import ICRS
+        from metapulsar.pint_helpers import create_pint_model
+
+        return (
+            create_pint_model(par_dict).get_psr_coords(epoch=epoch).transform_to(ICRS)
+        )
+
+    def test_transform_preserves_sky_direction_at_two_epochs(self):
+        import astropy.units as u
+
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(
+                reference_extra="ECL IERS2010\n",
+                other_extra="ECL IERS2010\n",
+                body=ECLIPTIC_BODY,
+            )
+        )
+        parfile_dicts = pm._parse_parfiles()
+        before = dict(parfile_dicts["EPTA"])
+
+        pm._transform_ecliptic_for_all(parfile_dicts, parfile_dicts["EPTA"])
+        after = parfile_dicts["EPTA"]
+
+        assert after["ECL"] == ["IERS2003"]
+        # A relabel would keep the printed ELONG/ELAT; this must not.
+        relabelled = dict(before)
+        relabelled["ECL"] = ["IERS2003"]
+
+        for epoch in (54000.0, 57000.0):
+            reference = self._icrs(before, epoch)
+            transformed = self._icrs(after, epoch)
+            relabel = self._icrs(relabelled, epoch)
+
+            assert reference.separation(transformed).to_value(u.arcsec) < 1e-7
+            # Guard: the test would pass trivially if a relabel were harmless.
+            assert reference.separation(relabel).to_value(u.arcsec) > 1e-5
+
+    def test_transform_replaces_lambda_beta_with_canonical_names(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(
+                reference_extra="ECL IERS2010\n",
+                other_extra="ECL IERS2010\n",
+                body=ECLIPTIC_BODY,
+            )
+        )
+        parfile_dicts = pm._parse_parfiles()
+        pm._transform_ecliptic_for_all(parfile_dicts, parfile_dicts["EPTA"])
+
+        par = parfile_dicts["EPTA"]
+        for alias in ("LAMBDA", "BETA", "PMLAMBDA", "PMBETA"):
+            assert alias not in par
+        for canonical in ("ELONG", "ELAT", "PMELONG", "PMELAT"):
+            assert canonical in par
+
+    def test_iers2003_input_in_mixed_stack_is_still_transformed_to_iers2003(self):
+        import astropy.units as u
+
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(
+                reference_extra="ECL IERS2003\n",
+                other_extra="ECL IERS2003\n",
+                body=ECLIPTIC_BODY,
+            )
+        )
+        parfile_dicts = pm._parse_parfiles()
+        before = dict(parfile_dicts["EPTA"])
+        pm._transform_ecliptic_for_all(parfile_dicts, parfile_dicts["EPTA"])
+        after = parfile_dicts["EPTA"]
+
+        assert after["ECL"] == ["IERS2003"]
+        assert (
+            self._icrs(before, 55000.0)
+            .separation(self._icrs(after, 55000.0))
+            .to_value(u.arcsec)
+            < 1e-7
+        )
+
+    def test_equatorial_stack_is_left_alone(self):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        parfile_dicts = pm._parse_parfiles()
+        before = {pta: dict(par) for pta, par in parfile_dicts.items()}
+
+        pm._transform_ecliptic_for_all(parfile_dicts, parfile_dicts["EPTA"])
+
+        assert parfile_dicts == before
+
+    def test_single_pta_astrometry_is_untouched(self):
+        pm = ParameterManager(
+            file_data={
+                "EPTA": {
+                    "timing_package": "tempo2",
+                    "par_content": self.ECL_BODY + "ECL IERS2010\n",
+                }
+            }
+        )
+        parfile_dicts = pm._parse_parfiles()
+        before = {pta: dict(par) for pta, par in parfile_dicts.items()}
+
+        pm._transform_ecliptic_for_all(parfile_dicts, parfile_dicts["EPTA"])
+
+        assert parfile_dicts == before
+
+    def test_ddk_kom_is_converted(self):
+        ddk_body = ECLIPTIC_BODY + (
+            "BINARY DDK\n"
+            "PB 14.348466\n"
+            "A1 8.801653\n"
+            "T0 55000.0\n"
+            "ECC 1.737e-04\n"
+            "OM 181.85\n"
+            "M2 0.33\n"
+            "KIN 68.0\n"
+            "KOM 76.0\n"
+            "PX 0.5\n"
+        )
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(
+                reference_extra="ECL IERS2010\n",
+                other_extra="ECL IERS2010\n",
+                body=ddk_body,
+            )
+        )
+        parfile_dicts = pm._parse_parfiles()
+        pm._transform_ecliptic_for_all(parfile_dicts, parfile_dicts["EPTA"])
+
+        par = parfile_dicts["EPTA"]
+        assert par["ECL"] == ["IERS2003"]
+        assert "KOM" in par
+        kom = float(str(par["KOM"][0]).split()[0])
+        # Same physical orientation, expressed against the new ecliptic pole.
+        assert kom == pytest.approx(76.0, abs=1e-2)
+
+    def test_conversion_failure_is_reported_with_the_pta_name(self):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        with pytest.raises(ValueError, match="PTA EPTA: ecliptic astrometry"):
+            pm._transform_ecliptic_astrometry(
+                "EPTA", {"ELONG": ["1"], "ELAT": ["2"]}, "IERS2003"
+            )
+
+
+class TestReferenceConventionResolution:
+    """Section 7.5: EPHEM and a dated clock realization."""
+
+    def test_reference_values_are_used_by_default(self):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        parfile_dicts = pm._parse_parfiles()
+
+        ephem, clock = pm._resolve_reference_conventions(parfile_dicts["EPTA"])
+
+        assert ephem == "DE440"
+        assert clock == "TT(BIPM2019)"
+
+    def test_policy_values_override_the_reference(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(),
+            alignment_policy=AlignmentPolicy(ephem="DE421", clock="TT(BIPM2023)"),
+        )
+        parfile_dicts = pm._parse_parfiles()
+
+        ephem, clock = pm._resolve_reference_conventions(parfile_dicts["EPTA"])
+
+        assert ephem == "DE421"
+        assert clock == "TT(BIPM2023)"
+
+    def test_policy_supplies_missing_reference_values(self):
+        pm = ParameterManager(
+            file_data={
+                "A": {
+                    "timing_package": "pint",
+                    "par_content": EQUATORIAL_BODY + "UNITS TDB\n",
+                },
+                "B": {
+                    "timing_package": "pint",
+                    "par_content": EQUATORIAL_BODY + "UNITS TDB\n",
+                },
+            },
+            alignment_policy=AlignmentPolicy(ephem="DE440", clock="TT(BIPM2021)"),
+        )
+        parfile_dicts = pm._parse_parfiles()
+
+        assert pm._resolve_reference_conventions(parfile_dicts["A"]) == (
+            "DE440",
+            "TT(BIPM2021)",
+        )
+
+    def test_clk_alias_is_accepted_and_spelling_is_retained(self):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        parfile_dicts = pm._parse_parfiles()
+        reference_dict = parfile_dicts["EPTA"]
+
+        align_conventions(pm, parfile_dicts, reference_dict)
+
+        assert parfile_dicts["EPTA"]["CLK"] == ["TT(BIPM2019)"]
+        assert parfile_dicts["NG"]["CLOCK"] == ["TT(BIPM2019)"]
+        assert "CLOCK" not in parfile_dicts["EPTA"]
+        assert "CLK" not in parfile_dicts["NG"]
+
+    def test_bare_bipm_without_version_raises(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(reference_extra="", body=EQUATORIAL_BODY)
+        )
+        parfile_dicts = pm._parse_parfiles()
+        parfile_dicts["EPTA"]["CLK"] = ["TT(BIPM)"]
+
+        with pytest.raises(ValueError, match="Bare TT\\(BIPM\\) is ambiguous"):
+            pm._resolve_reference_conventions(parfile_dicts["EPTA"])
+
+    def test_bare_bipm_resolves_with_policy_version(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(),
+            alignment_policy=AlignmentPolicy(bipm_version=2021),
+        )
+        parfile_dicts = pm._parse_parfiles()
+        parfile_dicts["EPTA"]["CLK"] = ["TT(BIPM)"]
+
+        _, clock = pm._resolve_reference_conventions(parfile_dicts["EPTA"])
+        assert clock == "TT(BIPM2021)"
+
+    def test_dated_clock_conflicting_with_bipm_version_raises(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(),
+            alignment_policy=AlignmentPolicy(clock="TT(BIPM2019)", bipm_version=2021),
+        )
+        parfile_dicts = pm._parse_parfiles()
+
+        with pytest.raises(ValueError, match="disagrees with"):
+            pm._resolve_reference_conventions(parfile_dicts["EPTA"])
+
+    def test_dated_clock_agreeing_with_bipm_version_is_accepted(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(),
+            alignment_policy=AlignmentPolicy(clock="TT(BIPM2019)", bipm_version=2019),
+        )
+        parfile_dicts = pm._parse_parfiles()
+
+        _, clock = pm._resolve_reference_conventions(parfile_dicts["EPTA"])
+        assert clock == "TT(BIPM2019)"
+
+    def test_non_bipm_clock_is_passed_through(self):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        assert pm._resolve_bipm_clock("UTC(NIST)") == "UTC(NIST)"
+
+
+class TestExplicitConventionSwitches:
+    """Section 4.1/4.2: forced switches only for mixed PINT+Tempo2 stacks."""
+
+    def _mixed_dicts(self, reference_extra="", other_extra=""):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(
+                reference_extra=reference_extra, other_extra=other_extra
+            )
+        )
+        parfile_dicts = pm._parse_parfiles()
+        pm._apply_explicit_conventions(parfile_dicts)
+        return parfile_dicts
+
+    def test_mixed_stack_writes_the_full_profile(self):
+        parfile_dicts = self._mixed_dicts()
+
+        for par in parfile_dicts.values():
+            assert par["UNITS"] == ["TDB"]
+            assert par["T2CMETHOD"] == ["IAU2000B"]
+            assert par["TIMEEPH"] == ["FB90"]
+            assert par["DILATEFREQ"] == ["N"]
+            assert par["CORRECT_TROPOSPHERE"] == ["N"]
+            assert par["PLANET_SHAPIRO"] == ["N"]
+            assert par["SWM"] == ["0"]
+            assert "NO_SS_SHAPIRO" not in par
+
+    def test_no_ss_shapiro_is_removed_independently_of_planet_shapiro(self):
+        parfile_dicts = self._mixed_dicts(
+            reference_extra="NO_SS_SHAPIRO\nPLANET_SHAPIRO Y\n"
+        )
+
+        assert "NO_SS_SHAPIRO" not in parfile_dicts["EPTA"]
+        assert parfile_dicts["EPTA"]["PLANET_SHAPIRO"] == ["N"]
+
+    def test_absent_no_ss_shapiro_stays_absent(self):
+        parfile_dicts = self._mixed_dicts()
+        assert "NO_SS_SHAPIRO" not in parfile_dicts["EPTA"]
+
+    def test_pint_only_stack_keeps_tropo_and_planet_settings(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(
+                reference_extra="CORRECT_TROPOSPHERE Y\nPLANET_SHAPIRO Y\n",
+                reference_package="pint",
+                other_package="pint",
+            )
+        )
+        parfile_dicts = pm._parse_parfiles()
+        pm._apply_explicit_conventions(parfile_dicts)
+
+        assert parfile_dicts["EPTA"]["CORRECT_TROPOSPHERE"] == ["Y"]
+        assert parfile_dicts["EPTA"]["PLANET_SHAPIRO"] == ["Y"]
+        assert "TIMEEPH" not in parfile_dicts["EPTA"]
+        assert "T2CMETHOD" not in parfile_dicts["EPTA"]
+        assert parfile_dicts["EPTA"]["UNITS"] == ["TDB"]
+
+    def test_tempo2_only_stack_keeps_tropo_and_planet_settings(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(
+                reference_extra="CORRECT_TROPOSPHERE Y\n",
+                reference_package="tempo2",
+                other_package="tempo2",
+            )
+        )
+        parfile_dicts = pm._parse_parfiles()
+        pm._apply_explicit_conventions(parfile_dicts)
+
+        assert parfile_dicts["EPTA"]["CORRECT_TROPOSPHERE"] == ["Y"]
+        assert "IPM" not in parfile_dicts["EPTA"]
+
+
+class TestEll1hHarmonics:
+    """Section 7.7: dual NHARM (tempo2) + NHARMS (PINT) floor of 7."""
+
+    def _align(self, extra_lines):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        par = parse_parfile(StringIO(extra_lines))
+        pm._align_ell1h_nharms(par)
+        return par
+
+    def test_h3_h4_without_harmonic_count_gets_seven(self):
+        par = self._align("BINARY ELL1H\nH3 1e-7\nH4 5e-8\n")
+        assert par["NHARM"] == ["7"]
+        assert par["NHARMS"] == ["7"]
+
+    def test_nharms_four_is_raised_to_seven(self):
+        par = self._align("BINARY ELL1H\nH3 1e-7\nH4 5e-8\nNHARMS 4\n")
+        assert par["NHARM"] == ["7"]
+        assert par["NHARMS"] == ["7"]
+
+    def test_nharm_four_is_raised_to_seven(self):
+        par = self._align("BINARY T2\nH3 1e-7\nH4 5e-8\nNHARM 4\n")
+        assert par["NHARM"] == ["7"]
+        assert par["NHARMS"] == ["7"]
+
+    def test_nharms_nine_is_preserved(self):
+        par = self._align("BINARY ELL1H\nH3 1e-7\nH4 5e-8\nNHARMS 9\n")
+        assert par["NHARM"] == ["9"]
+        assert par["NHARMS"] == ["9"]
+
+    def test_nharm_nine_is_preserved(self):
+        par = self._align("BINARY T2\nH3 1e-7\nH4 5e-8\nNHARM 9\n")
+        assert par["NHARM"] == ["9"]
+        assert par["NHARMS"] == ["9"]
+
+    def test_h3_stig_gets_no_harmonic_count(self):
+        par = self._align("BINARY ELL1H\nH3 1e-7\nSTIG 0.7\n")
+        assert "NHARM" not in par
+        assert "NHARMS" not in par
+
+    def test_h3_stigma_alias_gets_no_harmonic_count(self):
+        par = self._align("BINARY ELL1H\nH3 1e-7\nSTIGMA 0.7\n")
+        assert "NHARM" not in par
+        assert "NHARMS" not in par
+
+    @pytest.mark.parametrize("stigma_name", ["STIG", "STIGMA", "VARSIGMA"])
+    @pytest.mark.parametrize("unsupported", ["strip", "error"])
+    def test_h4_and_stigma_conflict_always_errors(self, stigma_name, unsupported):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(
+                reference_extra=(f"BINARY ELL1H\nH3 1e-7\nH4 5e-8\n{stigma_name} 0.7\n")
+            ),
+            alignment_policy=AlignmentPolicy(unsupported=unsupported),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=rf"PTA EPTA: invalid orthometric.*H4 and {stigma_name}",
+        ):
+            _prepared_dicts(pm)
+
+    def test_single_pta_h4_and_stig_conflict_errors(self):
+        pm = ParameterManager(
+            file_data={
+                "EPTA": {
+                    "timing_package": "tempo2",
+                    "par_content": (
+                        EQUATORIAL_BODY + "BINARY ELL1H\nH3 1e-7\nH4 5e-8\nSTIG 0.7\n"
+                    ),
+                }
+            }
+        )
+
+        with pytest.raises(ValueError, match="Tempo2 would ignore STIG"):
+            _prepared_dicts(pm)
+
+    def test_non_orthometric_binary_is_untouched(self):
+        par = self._align("BINARY DD\nPB 12.3\nA1 9.2\n")
+        assert "NHARM" not in par
+        assert "NHARMS" not in par
+
+    def test_both_spellings_survive_pint_serialization(self):
+        from metapulsar.pint_helpers import dict_to_parfile_string
+
+        par = self._align("BINARY ELL1H\nH3 1e-7\nH4 5e-8\n")
+        text = dict_to_parfile_string(par, format="pint")
+
+        assert "NHARM " in text or text.splitlines()[-2].startswith("NHARM")
+        reparsed = parse_parfile(StringIO(text))
+        assert reparsed["NHARM"] == ["7"]
+        assert reparsed["NHARMS"] == ["7"]
+
+
+class TestEll1hShapiroMode:
+    """Section 7.8: 'absorbed' only on mixed-engine consistent stacks."""
+
+    def test_mixed_stack_uses_absorbed(self):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        assert pm.ell1h_shapiro == "absorbed"
+
+    def test_pint_only_stack_uses_full(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(
+                reference_package="pint", other_package="pint"
+            )
+        )
+        assert pm.ell1h_shapiro == "full"
+
+    def test_tempo2_only_stack_uses_full(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(
+                reference_package="tempo2", other_package="tempo2"
+            )
+        )
+        assert pm.ell1h_shapiro == "full"
+
+    def test_single_pta_uses_full(self):
+        pm = ParameterManager(
+            file_data={
+                "EPTA": {
+                    "timing_package": "tempo2",
+                    "par_content": EQUATORIAL_BODY + "UNITS TDB\n",
+                }
+            }
+        )
+        assert pm.ell1h_shapiro == "full"
+
+    def test_libstempo_label_counts_as_tempo2(self):
+        pm = ParameterManager(
+            file_data=_cross_engine_file_data(reference_package="libstempo")
+        )
+        assert pm.ell1h_shapiro == "absorbed"
+
+    def test_resolve_helper(self):
+        from metapulsar.parameter_manager import resolve_ell1h_shapiro_mode
+
+        assert resolve_ell1h_shapiro_mode(["pint", "tempo2"]) == "absorbed"
+        assert resolve_ell1h_shapiro_mode(["pint", "pint"]) == "full"
+        assert resolve_ell1h_shapiro_mode(["tempo2"]) == "full"
+        assert resolve_ell1h_shapiro_mode([None]) == "full"
+
+    def test_temporary_models_use_the_stack_convention(self):
+        pm = ParameterManager(file_data=_cross_engine_file_data())
+        with patch("metapulsar.parameter_manager.create_pint_model") as mock_create:
+            pm._create_model("PSR J0000+0000\n")
+        mock_create.assert_called_once_with(
+            "PSR J0000+0000\n", ell1h_shapiro="absorbed"
+        )

--- a/tests/test_parameter_manager.py
+++ b/tests/test_parameter_manager.py
@@ -1359,6 +1359,45 @@ UNITS TDB
             model = create_pint_model(content)  # must not raise
             assert float(model.NE_SW.value) == pytest.approx(4.0)
 
+    def test_make_parfiles_consistent_writes_engine_native_clock_keys(self, tmp_path):
+        """PINT targets use CLOCK and Tempo2 targets use CLK after alignment."""
+        body = (
+            "PSR J1857+0943\nPEPOCH 55000\nF0 186.494081\nF1 -6.2e-16\n"
+            "RAJ 18:57:36.3937\nDECJ +09:43:17.291\nDM 13.299\n"
+            "EPHEM DE440\nUNITS TDB\n"
+        )
+        manager = ParameterManager(
+            file_data={
+                "NG": {
+                    "timing_package": "pint",
+                    "par_content": body + "CLK TT(BIPM2019)\n",
+                },
+                "EPTA": {
+                    "timing_package": "tempo2",
+                    "par_content": body + "CLOCK TT(BIPM2015)\n",
+                },
+            },
+            combine_components=[],
+            output_dir=tmp_path,
+            pulsar_name="J1857+0943",
+        )
+
+        output_files = manager.make_parfiles_consistent()
+
+        rows_by_pta = {}
+        for pta_name, path in output_files.items():
+            content = Path(path).read_text()
+            rows_by_pta[pta_name] = {
+                line.split()[0]: line.split()[1:]
+                for line in content.splitlines()
+                if line.strip() and not line.startswith("#")
+            }
+
+        assert rows_by_pta["NG"]["CLOCK"] == ["TT(BIPM2019)"]
+        assert "CLK" not in rows_by_pta["NG"]
+        assert rows_by_pta["EPTA"]["CLK"] == ["TT(BIPM2019)"]
+        assert "CLOCK" not in rows_by_pta["EPTA"]
+
 
 # ===================================================================
 # Complete cross-engine alignment: policy, stripping, transformations

--- a/tests/test_pint_helpers.py
+++ b/tests/test_pint_helpers.py
@@ -566,7 +566,7 @@ T0 55000.0 1
         # Should call ModelBuilder with dict directly
         mock_model_builder_class.assert_called_once()
         mock_builder.assert_called_once_with(
-            parfile_dict, allow_tcb=True, allow_T2=True
+            parfile_dict, allow_tcb=True, allow_T2=True, ell1h_shapiro="full"
         )
 
         assert result == mock_model

--- a/tests/test_release_shape_alignment.py
+++ b/tests/test_release_shape_alignment.py
@@ -1,0 +1,364 @@
+"""End-to-end alignment over representative PTA release shapes.
+
+Each case runs ``ParameterManager.make_parfiles_consistent()`` on compact
+checked-in par files (``tests/fixtures/release_shapes/``) and checks that the
+written par lands on the agreed common profile and still materializes through
+its declared timing engine.
+"""
+
+from __future__ import annotations
+
+import shutil
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from pint.models.model_builder import parse_parfile
+
+from metapulsar.parameter_manager import AlignmentPolicy, ParameterManager
+from metapulsar.pint_helpers import create_pint_model
+
+pytestmark = pytest.mark.slow
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "release_shapes"
+
+TEMPO2_AVAILABLE = shutil.which("tempo2") is not None
+needs_tempo2 = pytest.mark.skipif(
+    not TEMPO2_AVAILABLE, reason="tempo2 binary not available"
+)
+
+
+def read_shape(name: str) -> str:
+    return (FIXTURE_DIR / f"{name}.par").read_text(encoding="utf-8")
+
+
+def build_file_data(*shapes: tuple[str, str, str]) -> dict:
+    """Build ParameterManager file data from (pta_name, fixture, engine) triples."""
+    return {
+        pta_name: {
+            "par": FIXTURE_DIR / f"{fixture}.par",
+            "tim": FIXTURE_DIR / f"{fixture}.tim",
+            "timing_package": engine,
+            "par_content": read_shape(fixture),
+        }
+        for pta_name, fixture, engine in shapes
+    }
+
+
+def align(file_data: dict, tmp_path: Path, policy: AlignmentPolicy | None = None):
+    """Run the consistent strategy and return {pta: parsed par dict}."""
+    manager = ParameterManager(
+        file_data=file_data,
+        output_dir=tmp_path,
+        pulsar_name="J1600-3053",
+        alignment_policy=policy,
+    )
+    written = manager.make_parfiles_consistent()
+    # parse_parfile returns a defaultdict(list); make it a plain dict so a
+    # missing-key lookup in a test cannot silently create an empty entry.
+    return {
+        pta_name: dict(parse_parfile(StringIO(Path(path).read_text(encoding="utf-8"))))
+        for pta_name, path in written.items()
+    }, written
+
+
+def first(value):
+    return str(value[0]).split()[0]
+
+
+def tempo2_roundtrip(par_path: Path, out_path: Path) -> str:
+    """Round-trip a written par through tempo2 and return the result text."""
+    import subprocess
+
+    result = subprocess.run(
+        ["tempo2", "-gr", "transform", str(par_path), str(out_path), "tdb"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    return out_path.read_text(encoding="utf-8")
+
+
+class TestMixedEngineReleaseShapes:
+    """NANOGrav (PINT) + EPTA (Tempo2): the full section 4.1 profile."""
+
+    @pytest.fixture
+    def aligned(self, tmp_path):
+        file_data = build_file_data(
+            ("nanograv", "nanograv_style", "pint"),
+            ("epta", "epta_style", "tempo2"),
+        )
+        return align(file_data, tmp_path)
+
+    @needs_tempo2
+    def test_every_global_convention_is_explicit(self, aligned):
+        parsed, _ = aligned
+        for pta_name, par in parsed.items():
+            assert first(par["UNITS"]) == "TDB", pta_name
+            assert first(par["T2CMETHOD"]) == "IAU2000B", pta_name
+            assert first(par["TIMEEPH"]) == "FB90", pta_name
+            assert first(par["DILATEFREQ"]) == "N", pta_name
+            assert first(par["CORRECT_TROPOSPHERE"]) == "N", pta_name
+            assert first(par["PLANET_SHAPIRO"]) == "N", pta_name
+            assert first(par["SWM"]) == "0", pta_name
+            assert "NO_SS_SHAPIRO" not in par, pta_name
+
+    @needs_tempo2
+    def test_reference_ephemeris_and_clock_win(self, aligned):
+        parsed, _ = aligned
+        for pta_name, par in parsed.items():
+            assert first(par["EPHEM"]) == "DE436", pta_name
+            clock = par.get("CLOCK") or par["CLK"]
+            assert first(clock) == "TT(BIPM2017)", pta_name
+
+    @needs_tempo2
+    def test_ipm_is_a_tempo2_only_control(self, aligned):
+        parsed, _ = aligned
+        assert first(parsed["epta"]["IPM"]) == "1"
+        assert "IPM" not in parsed["nanograv"]
+
+    @needs_tempo2
+    def test_solar_wind_amplitude_is_explicit_and_canonical(self, aligned):
+        parsed, _ = aligned
+        for pta_name, par in parsed.items():
+            assert "SOLARN0" not in par, pta_name
+            assert "NE1AU" not in par, pta_name
+            # The reference PTA (NANOGrav) declares SOLARN0 0, which is explicit
+            # and therefore beats tempo2's implicit 4 cm^-3.
+            assert float(first(par["NE_SW"])) == pytest.approx(0.0)
+
+    @needs_tempo2
+    def test_ecliptic_frames_are_transformed_to_iers2003(self, aligned):
+        parsed, _ = aligned
+        for pta_name, par in parsed.items():
+            assert first(par["ECL"]) == "IERS2003", pta_name
+            assert "LAMBDA" not in par, pta_name
+            assert "BETA" not in par, pta_name
+            assert "ELONG" in par and "ELAT" in par, pta_name
+
+    @needs_tempo2
+    def test_merged_binary_without_h4_carries_no_harmonic_count(self, aligned):
+        parsed, _ = aligned
+        # The reference (NANOGrav) is a plain ELL1, so the binary merge replaces
+        # EPTA's H3+H4 model; a leftover harmonic count would be stale.
+        for pta_name, par in parsed.items():
+            assert first(par["BINARY"]) == "ELL1", pta_name
+            assert "H4" not in par, pta_name
+            assert "NHARM" not in par, pta_name
+            assert "NHARMS" not in par, pta_name
+
+    @needs_tempo2
+    def test_dispersion_cleanup_is_unchanged(self, aligned):
+        parsed, _ = aligned
+        for pta_name, par in parsed.items():
+            assert not any(key.startswith("DMX") for key in par), pta_name
+            assert par["DM1"] == ["0.0 1"], pta_name
+            assert par["DM2"] == ["0.0 1"], pta_name
+        # DM stays PTA-local by default.
+        assert float(first(parsed["nanograv"]["DM"])) == pytest.approx(52.3)
+
+    @needs_tempo2
+    def test_detector_local_terms_survive(self, aligned):
+        parsed, _ = aligned
+        nanograv = parsed["nanograv"]
+        assert nanograv["FD1"]
+        assert nanograv["FD2"]
+        assert len(nanograv["JUMP"]) == 2
+        assert nanograv["TZRMJD"] and nanograv["TZRSITE"] and nanograv["TZRFRQ"]
+
+        epta = parsed["epta"]
+        assert epta["JUMP"]
+        assert epta["FDDC"] and epta["FDDI"]
+
+    @needs_tempo2
+    def test_written_pars_load_in_pint(self, aligned):
+        _, written = aligned
+        for pta_name, path in written.items():
+            model = create_pint_model(
+                Path(path).read_text(encoding="utf-8"), ell1h_shapiro="absorbed"
+            )
+            assert model.PSR.value == "J1600-3053", pta_name
+
+    @needs_tempo2
+    def test_written_tempo2_par_is_accepted_by_tempo2(self, aligned, tmp_path):
+        _, written = aligned
+        roundtrip = tempo2_roundtrip(written["epta"], tmp_path / "roundtrip.par")
+        assert "J1600-3053" in roundtrip
+
+
+class TestAggregateAndUnsupportedShapes:
+    """TEMPO1 expansion, incidental DMMODEL, and development PINT extensions."""
+
+    @needs_tempo2
+    def test_tempo1_and_dmmodel_shape(self, tmp_path):
+        file_data = build_file_data(
+            ("nanograv", "nanograv_style", "pint"),
+            ("ppta", "ppta_style", "tempo2"),
+        )
+        parsed, _ = align(file_data, tmp_path)
+
+        ppta = parsed["ppta"]
+        # TEMPO1 is expanded, then normalized by the mixed-engine profile.
+        assert "TEMPO1" not in ppta
+        assert first(ppta["T2CMETHOD"]) == "IAU2000B"
+        assert first(ppta["TIMEEPH"]) == "FB90"
+        # DMMODEL and its grid are stripped; no basis conversion is attempted.
+        assert "DMMODEL" not in ppta
+        assert "_DM" not in ppta
+        assert "CONSTRAIN" not in ppta
+        assert first(ppta["UNITS"]) == "TDB"
+
+    def test_development_pint_extensions_are_stripped(self, tmp_path):
+        file_data = build_file_data(
+            ("mpta", "mpta_style", "pint"),
+            ("epta_pint", "pint_only_a", "tempo2"),
+        )
+        parsed, _ = align(file_data, tmp_path)
+
+        mpta = parsed["mpta"]
+        for key in (
+            "SWP",
+            "SWEPOCH",
+            "NE_SW1",
+            "SWXDM_0001",
+            "SWXR1_0001",
+            "SWXR2_0001",
+            "DMWXEPOCH",
+            "DMWXFREQ_0001",
+            "DMWXSIN_0001",
+            "DMWXCOS_0001",
+            "WXEPOCH",
+            "WXFREQ_0001",
+            "WXSIN_0001",
+            "WXCOS_0001",
+            "CM",
+            "CMEPOCH",
+            "CMX_0001",
+        ):
+            assert key not in mpta, f"{key} survived"
+        assert first(mpta["SWM"]) == "0"
+        # Ordinary red-noise settings are untouched.
+        assert mpta["TNREDAMP"] == ["-14.2"]
+        assert mpta["TNREDGAM"] == ["3.1"]
+
+    def test_error_policy_rejects_the_development_shape(self, tmp_path):
+        file_data = build_file_data(
+            ("mpta", "mpta_style", "pint"),
+            ("epta_pint", "pint_only_a", "tempo2"),
+        )
+        with pytest.raises(ValueError, match="unsupported timing parameters"):
+            align(file_data, tmp_path, AlignmentPolicy(unsupported="error"))
+
+
+class TestPintOnlyReleaseShape:
+    """A PINT-only multi-PTA stack keeps the thinner profile (section 4.2)."""
+
+    @pytest.fixture
+    def aligned(self, tmp_path):
+        file_data = build_file_data(
+            ("pta_a", "pint_only_a", "pint"),
+            ("pta_b", "pint_only_b", "pint"),
+        )
+        return align(file_data, tmp_path)
+
+    def test_troposphere_and_planet_shapiro_are_retained(self, aligned):
+        parsed, _ = aligned
+        for pta_name, par in parsed.items():
+            assert first(par["CORRECT_TROPOSPHERE"]) == "Y", pta_name
+            assert first(par["PLANET_SHAPIRO"]) == "Y", pta_name
+
+    def test_mixed_engine_switches_are_not_written(self, aligned):
+        parsed, _ = aligned
+        for pta_name, par in parsed.items():
+            assert "T2CMETHOD" not in par, pta_name
+            assert "TIMEEPH" not in par, pta_name
+            assert "IPM" not in par, pta_name
+
+    def test_heterogeneous_ecl_is_aligned_to_the_reference(self, aligned):
+        parsed, _ = aligned
+        for pta_name, par in parsed.items():
+            assert first(par["ECL"]) == "IERS2010", pta_name
+
+    def test_no_solar_wind_line_is_invented(self, aligned):
+        parsed, _ = aligned
+        for pta_name, par in parsed.items():
+            assert "NE_SW" not in par, pta_name
+
+
+class TestBinaryShapes:
+    """Binary families pass through their declared engine unchanged in family."""
+
+    @needs_tempo2
+    def test_ell1h_h3_stig_keeps_no_harmonic_count(self, tmp_path):
+        file_data = build_file_data(
+            ("pint_pta", "binary_ell1h_h3stig", "pint"),
+            ("t2_pta", "epta_style", "tempo2"),
+        )
+        parsed, _ = align(file_data, tmp_path)
+
+        # The reference PTA's binary values are copied across, so both pars end
+        # up on H3+STIG; neither may gain a harmonic count.
+        for pta_name, par in parsed.items():
+            assert "STIG" in par or "STIGMA" in par, pta_name
+            assert "NHARM" not in par, pta_name
+            assert "NHARMS" not in par, pta_name
+
+    @needs_tempo2
+    def test_binary_family_names_are_not_rewritten(self, tmp_path):
+        file_data = build_file_data(
+            ("pint_pta", "binary_ell1h_h3stig", "pint"),
+            ("t2_pta", "epta_style", "tempo2"),
+        )
+        parsed, _ = align(file_data, tmp_path)
+        for pta_name, par in parsed.items():
+            assert first(par["BINARY"]) == "ELL1H", pta_name
+
+    @needs_tempo2
+    def test_h3_h4_reference_gets_both_harmonic_spellings(self, tmp_path):
+        # EPTA is the reference here, so its T2 + H3 + H4 orthometric model is
+        # what every PTA ends up linearizing around.
+        file_data = build_file_data(
+            ("epta", "epta_style", "tempo2"),
+            ("nanograv", "nanograv_style", "pint"),
+        )
+        parsed, written = align(file_data, tmp_path)
+
+        for pta_name, par in parsed.items():
+            assert "H4" in par, pta_name
+            assert "STIG" not in par and "STIGMA" not in par, pta_name
+            assert int(first(par["NHARM"])) == 7, pta_name
+            assert int(first(par["NHARMS"])) == 7, pta_name
+
+        # Tempo2 only reads NHARM, so it must survive into the on-disk par.
+        roundtrip = tempo2_roundtrip(written["epta"], tmp_path / "roundtrip.par")
+        assert "NHARM" in roundtrip
+
+    @needs_tempo2
+    def test_existing_harmonic_count_above_the_floor_is_preserved(self, tmp_path):
+        raised = read_shape("epta_style").replace(
+            "H4               6.0e-08 1",
+            "H4               6.0e-08 1\nNHARM            9",
+        )
+        file_data = build_file_data(
+            ("epta", "epta_style", "tempo2"),
+            ("nanograv", "nanograv_style", "pint"),
+        )
+        file_data["epta"]["par_content"] = raised
+        parsed, _ = align(file_data, tmp_path)
+
+        for pta_name, par in parsed.items():
+            assert int(first(par["NHARM"])) == 9, pta_name
+            assert int(first(par["NHARMS"])) == 9, pta_name
+
+    @needs_tempo2
+    def test_ddk_kom_follows_the_ecliptic_transformation(self, tmp_path):
+        file_data = build_file_data(
+            ("t2_pta", "binary_ddk", "tempo2"),
+            ("pint_pta", "nanograv_style", "pint"),
+        )
+        parsed, _ = align(file_data, tmp_path)
+
+        ddk = parsed["t2_pta"]
+        assert first(ddk["ECL"]) == "IERS2003"
+        assert "KOM" in ddk
+        assert float(first(ddk["KOM"])) == pytest.approx(76.0, abs=1e-2)


### PR DESCRIPTION
## Summary
- Align multi-PTA `consistent` combination onto a validated mixed PINT/Tempo2 surface: engine-gated timescale policy, convention normalization, and early rejection of ambiguous models (e.g. incompatible orthometric Shapiro parameters), while preserving native single-engine/single-PTA behavior.
- Preserve each PTA’s `timing_package` into `ParameterManager` so rewrite rules are engine-aware, and emit clock keywords in the target engine’s native spelling (`CLOCK` for PINT, `CLK` for Tempo2) so Tempo2 does not silently ignore the aligned clock.
- Add release-shape fixtures and expanded unit/integration coverage (cross-engine parity, factory, parameter manager, legacy comparison) plus docs updates for the new alignment policy.

## Test plan
- [x] `make fast` (or at least `pytest tests/test_parameter_manager.py tests/test_release_shape_alignment.py tests/test_cross_engine_parity.py tests/test_metapulsar_factory.py -v`)
- [x] Confirm mixed PINT+Tempo2 `consistent` runs write `CLOCK` on PINT targets and `CLK` on Tempo2 targets with the same resolved clock value
- [x] Confirm invalid H3/H4/STIG combinations still fail early under `consistent`
- [x] Spot-check a known NG15y→Tempo2 aligned case that previously showed ~hundreds-of-ns residuals after the CLOCK/CLK mismatch (should drop once `CLK` is written)